### PR TITLE
Set up workspace dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = [
+    "tpde",
+    "tpde-encodegen",
+    "tpde-llvm"
+]
+
+resolver = "2"
+
+[workspace.dependencies]
+inkwell = { version = "0.2" }
+object = { version = "0.32" }
+cbindgen = { version = "0.26" }

--- a/rust/tpde-encodegen/Cargo.toml
+++ b/rust/tpde-encodegen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tpde-encodegen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+inkwell = { workspace = true }
+
+[[bin]]
+name = "tpde-encodegen"
+path = "src/main.rs"

--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("tpde-encodegen placeholder");
+}

--- a/rust/tpde-llvm/Cargo.toml
+++ b/rust/tpde-llvm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tpde-llvm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+inkwell = { workspace = true }
+
+[lib]
+path = "src/lib.rs"

--- a/rust/tpde-llvm/src/lib.rs
+++ b/rust/tpde-llvm/src/lib.rs
@@ -1,0 +1,5 @@
+//! TPDE LLVM backend in Rust.
+
+pub fn compiler() -> &'static str {
+    "TPDE LLVM backend"
+}

--- a/rust/tpde/Cargo.toml
+++ b/rust/tpde/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tpde"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+object = { workspace = true }

--- a/rust/tpde/src/lib.rs
+++ b/rust/tpde/src/lib.rs
@@ -1,0 +1,5 @@
+//! Core TPDE framework in Rust.
+
+pub fn hello() -> &'static str {
+    "Hello from tpde"
+}


### PR DESCRIPTION
## Summary
- centralize dependencies under `[workspace.dependencies]`
- reference workspace deps in each crate
- add `object` crate to `tpde`

## Testing
- `cargo check --workspace --offline` *(fails: no matching package named `object`)*

------
https://chatgpt.com/codex/tasks/task_e_683e0e480dac832698e07aafb8b6aca8