### PR TITLE
Sketch core APIs for TPDE rewrite

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "tpde",
+    "tpde-core",
     "tpde-encodegen",
     "tpde-llvm"
 ]

--- a/rust/tpde-core/Cargo.toml
+++ b/rust/tpde-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tpde"
+name = "tpde-core"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/tpde-core/src/adaptor.rs
+++ b/rust/tpde-core/src/adaptor.rs
@@ -1,0 +1,31 @@
+/// Trait describing the interface between TPDE and a user IR.
+///
+/// Types implementing this trait provide references to functions,
+/// blocks and values and allow the compiler to query basic
+/// information about them. Only a small subset of the full C++
+/// interface is modeled here so far.
+pub trait IrAdaptor {
+    type ValueRef: Copy + Eq;
+    type InstRef: Copy + Eq;
+    type BlockRef: Copy + Eq;
+    type FuncRef: Copy + Eq;
+
+    const INVALID_VALUE_REF: Self::ValueRef;
+    const INVALID_BLOCK_REF: Self::BlockRef;
+    const INVALID_FUNC_REF: Self::FuncRef;
+
+    /// Number of functions contained in the module.
+    fn func_count(&self) -> u32;
+
+    /// Iterator over all functions in the module.
+    fn funcs(&self) -> Box<dyn Iterator<Item = Self::FuncRef> + '_>;
+
+    /// Linkage name of the function.
+    fn func_link_name(&self, func: Self::FuncRef) -> &str;
+
+    /// Switch to the given function before compilation.
+    fn switch_func(&mut self, func: Self::FuncRef) -> bool;
+
+    /// Reset internal state between compilation runs.
+    fn reset(&mut self);
+}

--- a/rust/tpde-core/src/analyzer.rs
+++ b/rust/tpde-core/src/analyzer.rs
@@ -1,0 +1,22 @@
+use crate::adaptor::IrAdaptor;
+use core::marker::PhantomData;
+
+/// Computes block layout and liveness information for a function.
+#[allow(dead_code)]
+pub struct Analyzer<A: IrAdaptor> {
+    _marker: PhantomData<A>,
+}
+
+impl<A: IrAdaptor> Analyzer<A> {
+    /// Create a new analyzer.
+    pub fn new() -> Self {
+        Self { _marker: PhantomData }
+    }
+
+    /// Build block layout and liveness for the given function using the adaptor.
+    pub fn switch_func(&mut self, adaptor: &mut A, func: A::FuncRef) {
+        let _ = adaptor.switch_func(func);
+        // detailed analysis to be implemented later
+        todo!()
+    }
+}

--- a/rust/tpde-core/src/assembler.rs
+++ b/rust/tpde-core/src/assembler.rs
@@ -1,0 +1,18 @@
+use crate::adaptor::IrAdaptor;
+
+/// Trait implemented by architecture specific assemblers.
+pub trait Assembler<A: IrAdaptor> {
+    type SymRef;
+    type Label;
+
+    /// Create a new assembler.
+    fn new(generate_object: bool) -> Self
+    where
+        Self: Sized;
+
+    fn label_create(&mut self) -> Self::Label;
+    fn label_place(&mut self, label: Self::Label);
+
+    fn sym_predef_func(&mut self, name: &str, local: bool, weak: bool) -> Self::SymRef;
+    fn sym_add_undef(&mut self, name: &str, local: bool, weak: bool);
+}

--- a/rust/tpde-core/src/compiler.rs
+++ b/rust/tpde-core/src/compiler.rs
@@ -1,0 +1,33 @@
+use crate::{adaptor::IrAdaptor, analyzer::Analyzer, assembler::Assembler};
+
+/// Architecture independent compiler driver.
+#[allow(dead_code)]
+pub struct CompilerBase<A: IrAdaptor, ASM: Assembler<A>> {
+    adaptor: A,
+    analyzer: Analyzer<A>,
+    assembler: ASM,
+}
+
+impl<A: IrAdaptor, ASM: Assembler<A>> CompilerBase<A, ASM> {
+    /// Create a new compiler base from an adaptor and assembler.
+    pub fn new(adaptor: A, assembler: ASM) -> Self {
+        Self {
+            adaptor,
+            analyzer: Analyzer::new(),
+            assembler,
+        }
+    }
+
+    /// Compile all functions provided by the adaptor.
+    pub fn compile(&mut self) -> bool {
+        let funcs: Vec<_> = self.adaptor.funcs().collect();
+        for func in funcs {
+            if !self.adaptor.switch_func(func) {
+                continue;
+            }
+            self.analyzer.switch_func(&mut self.adaptor, func);
+            // architecture specific code generation would go here
+        }
+        true
+    }
+}

--- a/rust/tpde-core/src/lib.rs
+++ b/rust/tpde-core/src/lib.rs
@@ -1,0 +1,11 @@
+//! Core TPDE framework in Rust.
+
+pub mod adaptor;
+pub mod analyzer;
+pub mod assembler;
+pub mod compiler;
+
+/// Temporary hello world to prove the crate builds.
+pub fn hello() -> &'static str {
+    "Hello from tpde"
+}

--- a/rust/tpde-encodegen/Cargo.toml
+++ b/rust/tpde-encodegen/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 inkwell = { workspace = true }
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "tpde-encodegen"
 path = "src/main.rs"

--- a/rust/tpde-encodegen/src/lib.rs
+++ b/rust/tpde-encodegen/src/lib.rs
@@ -1,0 +1,9 @@
+//! Encoding snippet generator entry points.
+
+use inkwell::module::Module;
+
+/// Parse the provided LLVM IR module and emit snippet encoders.
+#[allow(dead_code)]
+pub fn generate(_module: &Module) {
+    todo!("encode generation not yet implemented")
+}

--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("tpde-encodegen placeholder");
+    // real functionality will be provided through the library API
 }

--- a/rust/tpde-llvm/Cargo.toml
+++ b/rust/tpde-llvm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 inkwell = { workspace = true }
+tpde-core = { path = "../tpde-core" }
 
 [lib]
 path = "src/lib.rs"

--- a/rust/tpde-llvm/src/lib.rs
+++ b/rust/tpde-llvm/src/lib.rs
@@ -1,5 +1,22 @@
 //! TPDE LLVM backend in Rust.
 
+use inkwell::module::Module;
+use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::CompilerBase};
+
+/// Compile an LLVM `Module` using a TPDE compiler setup.
+pub fn compile_ir<A, ASM>(
+    _module: &Module,
+    _adaptor: A,
+    _assembler: ASM,
+) -> CompilerBase<A, ASM>
+where
+    A: IrAdaptor,
+    ASM: Assembler<A>,
+{
+    unimplemented!("LLVM compilation not yet implemented")
+}
+
+/// Simple text marker proving the crate works.
 pub fn compiler() -> &'static str {
     "TPDE LLVM backend"
 }

--- a/rust/tpde/src/lib.rs
+++ b/rust/tpde/src/lib.rs
@@ -1,5 +1,0 @@
-//! Core TPDE framework in Rust.
-
-pub fn hello() -> &'static str {
-    "Hello from tpde"
-}


### PR DESCRIPTION
## Summary
- rename the main Rust crate to `tpde-core`
- update workspace and dependent crates
- keep LLVM backend using the new core crate

## Testing
- `cargo check --manifest-path rust/Cargo.toml --offline`


------
https://chatgpt.com/codex/tasks/task_e_683e19bd19dc8326a82eb7307bc53732