### PR TITLE
Add minimal tpde-encodegen CLI

### DIFF
--- a/rust/tpde-encodegen/src/lib.rs
+++ b/rust/tpde-encodegen/src/lib.rs
@@ -10,8 +10,10 @@
 
 use inkwell::module::Module;
 
-/// Parse the provided LLVM IR module and emit snippet encoders.
-#[allow(dead_code)]
-pub fn generate(_module: &Module) {
-    todo!("encode generation not yet implemented")
+/// Generate snippet encoder source from the provided LLVM IR `Module`.
+///
+/// The current implementation simply returns a placeholder string.  Real
+/// logic will analyse the IR and emit encoder functions.
+pub fn generate(_module: &Module) -> String {
+    "// encode generation not yet implemented\n".to_string()
 }

--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,8 +1,84 @@
 /// CLI entry point for snippet encoder generation.
 ///
-/// At the moment this only prints a placeholder message.  The real work is done
-/// in [`tpde_encodegen::generate`].  See [`tpde_core::overview`] for an
-/// overview of the intended workflow.
-fn main() {
-    println!("tpde-encodegen placeholder");
+/// The program expects an input LLVM IR file and optionally an output file
+/// passed via `-o` or `--output`.  The generated source is written to stdout
+/// when no output file is specified.
+use std::{env, fs::File, io::{self, Read, Write}, process::exit};
+
+use inkwell::{context::Context, memory_buffer::MemoryBuffer};
+
+fn print_help(program: &str) {
+    println!(
+        "Usage: {program} <input> [-o <output>]\n\n\
+Generate snippet encoders from LLVM IR.  Output defaults to stdout." );
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = None;
+    let mut output = None;
+
+    let mut args = env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-o" | "--output" => {
+                output = args.next();
+                if output.is_none() {
+                    eprintln!("missing argument for {}", arg);
+                    let prog = env::args().next().unwrap_or_default();
+                    print_help(&prog);
+                    exit(1);
+                }
+            }
+            "-h" | "--help" => {
+                let prog = env::args().next().unwrap_or_default();
+                print_help(&prog);
+                return Ok(());
+            }
+            _ => {
+                if input.is_none() {
+                    input = Some(arg);
+                } else {
+                    eprintln!("unexpected argument: {}", arg);
+                    let prog = env::args().next().unwrap_or_default();
+                    print_help(&prog);
+                    exit(1);
+                }
+            }
+        }
+    }
+
+    let prog = env::args().next().unwrap_or_else(|| "tpde-encodegen".into());
+    let input_path = match input {
+        Some(p) => p,
+        None => {
+            print_help(&prog);
+            exit(1);
+        }
+    };
+
+    let ir = {
+        let mut buf = Vec::new();
+        File::open(&input_path)?.read_to_end(&mut buf)?;
+        buf
+    };
+
+    let context = Context::create();
+    let buffer = MemoryBuffer::create_from_memory_range_copy(&ir, &input_path);
+    let module = context
+        .create_module_from_ir(buffer)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+    let generated = tpde_encodegen::generate(&module);
+
+    match output {
+        Some(path) => {
+            let mut file = File::create(path)?;
+            file.write_all(generated.as_bytes())?;
+        }
+        None => {
+            io::stdout().write_all(generated.as_bytes())?;
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- implement a placeholder `generate` that returns a string
- add a simple command line interface for `tpde-encodegen`

## Testing
- `cargo check -p tpde-encodegen --offline`
- `cargo build -p tpde-encodegen --offline` *(fails: could not find native static library `Polly`)*

------
https://chatgpt.com/codex/tasks/task_e_683e226d6b0c8326871d0521a58db51d