### PR TITLE
Add basic encode generator

### DIFF
--- a/rust/tpde-encodegen/src/lib.rs
+++ b/rust/tpde-encodegen/src/lib.rs
@@ -8,7 +8,43 @@
 //! writing every pattern by hand. See [`tpde_core::overview`] for an
 //! extended overview.
 
-use inkwell::module::Module;
+use inkwell::{
+    context::Context,
+    memory_buffer::MemoryBuffer,
+    module::Module,
+};
+
+/// Parse a text LLVM IR module.
+pub fn parse_module<'ctx>(context: &'ctx Context, ir: &str) -> Result<Module<'ctx>, String> {
+    let buffer = MemoryBuffer::create_from_memory_range_copy(ir.as_bytes(), "ir");
+    context
+        .create_module_from_ir(buffer)
+        .map_err(|e| e.to_string())
+}
+
+/// Generate Rust source snippets for functions starting with `pattern_`.
+pub fn generate_tokens(module: &Module) -> Vec<String> {
+    module
+        .get_functions()
+        .filter_map(|f| {
+            let name = f.get_name().to_str().ok()?;
+            if let Some(rest) = name.strip_prefix("pattern_") {
+                Some(format!("pub fn {}() {{ /* machine code */ }}", rest))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Convenience helper parsing IR text and returning token strings.
+pub fn parse_and_generate<'ctx>(
+    context: &'ctx Context,
+    ir: &str,
+) -> Result<Vec<String>, String> {
+    let module = parse_module(context, ir)?;
+    Ok(generate_tokens(&module))
+}
 
 /// Parse the provided LLVM IR module and emit snippet encoders.
 #[allow(dead_code)]

--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,8 +1,27 @@
 /// CLI entry point for snippet encoder generation.
 ///
-/// At the moment this only prints a placeholder message.  The real work is done
-/// in [`tpde_encodegen::generate`].  See [`tpde_core::overview`] for an
-/// overview of the intended workflow.
+/// This parses an LLVM IR file and writes the generated Rust snippets
+/// to the provided output path. If no output is specified the snippets
+/// are printed to stdout.
+use std::{env, fs};
+
+use inkwell::context::Context;
+
 fn main() {
-    println!("tpde-encodegen placeholder");
+    let mut args = env::args().skip(1);
+    let input = args.next().expect("missing input file");
+    let output = args.next();
+
+    let ir = fs::read_to_string(&input).expect("failed to read input");
+    let context = Context::create();
+    let module = tpde_encodegen::parse_module(&context, &ir).expect("parse error");
+    let tokens = tpde_encodegen::generate_tokens(&module);
+
+    if let Some(out) = output {
+        fs::write(out, tokens.join("\n")).expect("failed to write output");
+    } else {
+        for t in tokens {
+            println!("{}", t);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement parsing of text LLVM IR using inkwell
- generate stub Rust functions for `pattern_` prefixed IR functions
- expose CLI that writes tokens to file or stdout

## Testing
- `cargo check --all-targets --workspace --offline`

------
https://chatgpt.com/codex/tasks/task_e_683e226c55408326b33d234b9fe918d0