### PR TITLE
Add basic LLVM adaptor scaffold

### DIFF
--- a/rust/tpde-llvm/src/lib.rs
+++ b/rust/tpde-llvm/src/lib.rs
@@ -7,20 +7,120 @@
 //! handled by falling back to LLVM.  A condensed description of the original
 //! design and current limitations lives in [`tpde_core::overview`].
 
-use inkwell::module::Module;
+use inkwell::{
+    basic_block::BasicBlock,
+    module::Module,
+    values::{BasicValueEnum, FunctionValue, InstructionValue},
+};
 use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::CompilerBase};
 
-/// Compile an LLVM `Module` using a TPDE compiler setup.
-pub fn compile_ir<A, ASM>(
-    _module: &Module,
-    _adaptor: A,
-    _assembler: ASM,
-) -> CompilerBase<A, ASM>
-where
-    A: IrAdaptor,
-    ASM: Assembler<A>,
-{
-    unimplemented!("LLVM compilation not yet implemented")
+/// Adaptor walking an LLVM [`Module`] using `inkwell`.
+///
+/// This very small implementation only exposes functions which is enough for
+/// [`CompilerBase::compile`].  Values, blocks and instructions are represented
+/// as `Option` types so we can define an invalid constant.
+pub struct LlvmIrAdaptor<'ctx> {
+    module: Module<'ctx>,
+    funcs: Vec<FunctionValue<'ctx>>,
+    names: Vec<String>,
+    current: Option<FunctionValue<'ctx>>,
+}
+
+impl<'ctx> LlvmIrAdaptor<'ctx> {
+    /// Create a new adaptor collecting all functions in the module.
+    pub fn new(module: &Module<'ctx>) -> Self {
+        let funcs: Vec<_> = module.get_functions().collect();
+        let names = funcs
+            .iter()
+            .map(|f| f.get_name().to_str().unwrap_or("").to_string())
+            .collect();
+        Self {
+            module: module.clone(),
+            funcs,
+            names,
+            current: None,
+        }
+    }
+}
+
+impl<'ctx> IrAdaptor for LlvmIrAdaptor<'ctx> {
+    type ValueRef = Option<BasicValueEnum<'ctx>>;
+    type InstRef = Option<InstructionValue<'ctx>>;
+    type BlockRef = Option<BasicBlock<'ctx>>;
+    type FuncRef = Option<FunctionValue<'ctx>>;
+
+    const INVALID_VALUE_REF: Self::ValueRef = None;
+    const INVALID_BLOCK_REF: Self::BlockRef = None;
+    const INVALID_FUNC_REF: Self::FuncRef = None;
+
+    fn func_count(&self) -> u32 {
+        self.funcs.len() as u32
+    }
+
+    fn funcs(&self) -> Box<dyn Iterator<Item = Self::FuncRef> + '_> {
+        Box::new(self.funcs.iter().cloned().map(Some))
+    }
+
+    fn func_link_name(&self, func: Self::FuncRef) -> &str {
+        if let Some(f) = func {
+            if let Some(pos) = self.funcs.iter().position(|&fv| fv == f) {
+                return &self.names[pos];
+            }
+        }
+        ""
+    }
+
+    fn switch_func(&mut self, func: Self::FuncRef) -> bool {
+        self.current = func;
+        func.is_some()
+    }
+
+    fn reset(&mut self) {
+        self.current = None;
+    }
+}
+
+/// Minimal assembler that satisfies [`Assembler`].
+pub struct NullAssembler {
+    next_label: usize,
+}
+
+impl NullAssembler {
+    pub fn new(_: bool) -> Self {
+        Self { next_label: 0 }
+    }
+}
+
+impl<A: IrAdaptor> Assembler<A> for NullAssembler {
+    type SymRef = ();
+    type Label = usize;
+
+    fn new(generate_object: bool) -> Self {
+        Self::new(generate_object)
+    }
+
+    fn label_create(&mut self) -> Self::Label {
+        let id = self.next_label;
+        self.next_label += 1;
+        id
+    }
+
+    fn label_place(&mut self, _label: Self::Label) {}
+
+    fn sym_predef_func(&mut self, _name: &str, _local: bool, _weak: bool) -> Self::SymRef {}
+
+    fn sym_add_undef(&mut self, _name: &str, _local: bool, _weak: bool) {}
+}
+
+/// Build a [`CompilerBase`] ready to process the LLVM `Module`.
+///
+/// The returned compiler can immediately run [`CompilerBase::compile`].  The
+/// current implementation only gathers functions; instruction selection is
+/// still a stub.
+pub fn compile_ir<'ctx>(module: &Module<'ctx>) -> CompilerBase<LlvmIrAdaptor<'ctx>, NullAssembler> {
+    let adaptor = LlvmIrAdaptor::new(module);
+    let assembler = NullAssembler::new(false);
+    CompilerBase::new(adaptor, assembler)
 }
 
 /// Simple text marker proving the crate works.


### PR DESCRIPTION
## Summary
- implement `LlvmIrAdaptor` using inkwell to collect functions
- provide a stub `NullAssembler`
- hook up `compile_ir` to create `CompilerBase`

## Testing
- `cargo check --workspace --offline`
- `cargo test --workspace --offline --no-run` *(fails: could not find native static library `Polly`)*

------
https://chatgpt.com/codex/tasks/task_e_683e226de6f483268fb111d9fb6f3877