### PR TITLE
Add analyzer block order & liveness

### DIFF
--- a/rust/tpde-core/src/adaptor.rs
+++ b/rust/tpde-core/src/adaptor.rs
@@ -28,7 +28,7 @@
 pub trait IrAdaptor {
     type ValueRef: Copy + Eq;
     type InstRef: Copy + Eq;
-    type BlockRef: Copy + Eq;
+    type BlockRef: Copy + Eq + core::hash::Hash;
     type FuncRef: Copy + Eq;
 
     const INVALID_VALUE_REF: Self::ValueRef;
@@ -49,4 +49,28 @@ pub trait IrAdaptor {
 
     /// Reset internal state between compilation runs.
     fn reset(&mut self);
+
+    /// Entry block of the currently selected function.
+    fn entry_block(&self) -> Self::BlockRef;
+
+    /// Iterator over all blocks in the current function.
+    fn blocks(&self) -> Box<dyn Iterator<Item = Self::BlockRef> + '_>;
+
+    /// Successor blocks of a given block.
+    fn block_succs(&self, block: Self::BlockRef) -> Box<dyn Iterator<Item = Self::BlockRef> + '_>;
+
+    /// Iterator over instructions contained in a block.
+    fn block_insts(&self, block: Self::BlockRef) -> Box<dyn Iterator<Item = Self::InstRef> + '_>;
+
+    /// Result values produced by an instruction.
+    fn inst_results(&self, inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_>;
+
+    /// Operands referenced by an instruction.
+    fn inst_operands(&self, inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_>;
+
+    /// Local index of a value for liveness tracking.
+    fn val_local_idx(&self, val: Self::ValueRef) -> usize;
+
+    /// Should this value be ignored during liveness analysis?
+    fn val_ignore_liveness(&self, val: Self::ValueRef) -> bool;
 }

--- a/rust/tpde-core/src/analyzer.rs
+++ b/rust/tpde-core/src/analyzer.rs
@@ -1,5 +1,19 @@
 use crate::adaptor::IrAdaptor;
 use core::marker::PhantomData;
+use std::collections::{HashMap, HashSet};
+
+/// Liveness information for a single value.
+#[derive(Default, Clone, Copy)]
+pub struct LivenessInfo {
+    /// Index of the first block this value is live in.
+    pub first: usize,
+    /// Index of the last block this value is live in.
+    pub last: usize,
+    /// Number of uses including the definition.
+    pub ref_count: u32,
+    /// Whether the value must stay allocated until the end of `last`.
+    pub last_full: bool,
+}
 
 /// Computes block layout and liveness information for a function.
 ///
@@ -11,19 +25,105 @@ use core::marker::PhantomData;
 /// skeleton.
 #[allow(dead_code)]
 pub struct Analyzer<A: IrAdaptor> {
+    order: Vec<A::BlockRef>,
+    block_map: HashMap<A::BlockRef, usize>,
+    liveness: Vec<LivenessInfo>,
     _marker: PhantomData<A>,
 }
 
 impl<A: IrAdaptor> Analyzer<A> {
     /// Create a new analyzer.
     pub fn new() -> Self {
-        Self { _marker: PhantomData }
+        Self {
+            order: Vec::new(),
+            block_map: HashMap::new(),
+            liveness: Vec::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Sequence of blocks in reverse post order.
+    pub fn order(&self) -> &[A::BlockRef] {
+        &self.order
+    }
+
+    /// Liveness information for a value index.
+    pub fn liveness(&self, idx: usize) -> Option<&LivenessInfo> {
+        self.liveness.get(idx)
     }
 
     /// Build block layout and liveness for the given function using the adaptor.
     pub fn switch_func(&mut self, adaptor: &mut A, func: A::FuncRef) {
-        let _ = adaptor.switch_func(func);
-        // detailed analysis to be implemented later
-        todo!()
+        self.order.clear();
+        self.block_map.clear();
+        self.liveness.clear();
+
+        if !adaptor.switch_func(func) {
+            return;
+        }
+
+        // -------- build RPO order ---------
+        let entry = adaptor.entry_block();
+        let mut post = Vec::new();
+        let mut stack = vec![(entry, false)];
+        let mut visited = HashSet::new();
+        while let Some((block, processed)) = stack.pop() {
+            if processed {
+                post.push(block);
+                continue;
+            }
+            if !visited.insert(block) {
+                continue;
+            }
+            stack.push((block, true));
+            for succ in adaptor.block_succs(block) {
+                stack.push((succ, false));
+            }
+        }
+        post.reverse();
+        self.order = post;
+        for (idx, b) in self.order.iter().enumerate() {
+            self.block_map.insert(*b, idx);
+        }
+
+        // -------- compute liveness ---------
+        for idx in 0..self.order.len() {
+            let block = self.order[idx];
+            for inst in adaptor.block_insts(block) {
+                for val in adaptor.inst_results(inst) {
+                    self.record(adaptor, val, idx);
+                }
+                for val in adaptor.inst_operands(inst) {
+                    self.record(adaptor, val, idx);
+                }
+            }
+        }
+    }
+
+    fn record(&mut self, adaptor: &A, val: A::ValueRef, block_idx: usize) {
+        if adaptor.val_ignore_liveness(val) {
+            return;
+        }
+        let idx = adaptor.val_local_idx(val);
+        if idx >= self.liveness.len() {
+            self.liveness.resize(
+                idx + 1,
+                LivenessInfo { first: block_idx, last: block_idx, ref_count: 0, last_full: false },
+            );
+        }
+        let info = &mut self.liveness[idx];
+        info.ref_count += 1;
+        if info.ref_count == 1 {
+            info.first = block_idx;
+            info.last = block_idx;
+        } else {
+            if block_idx < info.first {
+                info.first = block_idx;
+            }
+            if block_idx > info.last {
+                info.last = block_idx;
+            }
+        }
+        info.last_full = info.first != info.last;
     }
 }


### PR DESCRIPTION
## Summary
- expand `IrAdaptor` with block and value helpers
- implement basic reverse post-order traversal in the Rust `Analyzer`
- track liveness ranges for values
- expose methods to query block order and liveness info

## Testing
- `cargo check --quiet --workspace --offline`
- `cargo test --workspace --offline --quiet` *(fails: could not find native static library `Polly`)*

------
https://chatgpt.com/codex/tasks/task_e_683e2269a70c832689035c7931bc5fc9