### PR TITLE
Add extensible backend hooks

### DIFF
--- a/rust/tpde-core/src/adaptor.rs
+++ b/rust/tpde-core/src/adaptor.rs
@@ -49,4 +49,10 @@ pub trait IrAdaptor {
 
     /// Reset internal state between compilation runs.
     fn reset(&mut self);
+
+    /// Iterate over all blocks of the current function.
+    fn blocks(&self, func: Self::FuncRef) -> Box<dyn Iterator<Item = Self::BlockRef> + '_>;
+
+    /// Iterate over all instructions in a block.
+    fn block_insts(&self, block: Self::BlockRef) -> Box<dyn Iterator<Item = Self::InstRef> + '_>;
 }

--- a/rust/tpde-core/src/assembler.rs
+++ b/rust/tpde-core/src/assembler.rs
@@ -21,4 +21,17 @@ pub trait Assembler<A: IrAdaptor> {
 
     fn sym_predef_func(&mut self, name: &str, local: bool, weak: bool) -> Self::SymRef;
     fn sym_add_undef(&mut self, name: &str, local: bool, weak: bool);
+
+    /// Finalize sections and relocations after code generation.
+    fn finalize(&mut self);
+
+    /// Write a finished object file to a byte vector.
+    fn build_object_file(&mut self) -> Vec<u8>;
+
+    /// Map the generated code into memory for JIT execution.
+    ///
+    /// `resolve` should return the address of any unresolved symbol.
+    fn map<F>(&mut self, resolve: F) -> bool
+    where
+        F: FnMut(&str) -> *const u8;
 }

--- a/rust/tpde-core/src/lib.rs
+++ b/rust/tpde-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod adaptor;
 pub mod analyzer;
 pub mod assembler;
 pub mod compiler;
+pub use compiler::{Backend, CompilerBase};
 
 /// Temporary hello world to prove the crate builds.
 pub fn hello() -> &'static str {

--- a/rust/tpde-core/src/overview.rs
+++ b/rust/tpde-core/src/overview.rs
@@ -50,6 +50,8 @@
 //!   instructions and managing register allocation.
 //! - The assembler collects sections, relocations and unwind data and finally
 //!   writes an ELF object or maps the code into memory.
+//! - Users implement [`Backend`] to drive instruction selection and emit
+//!   prologue/epilogue code for each function.
 //!
 //! TPDE is intended for baseline code generation. It trades heavy
 //! optimization passes for very fast compile times while still delivering

--- a/rust/tpde-llvm/src/lib.rs
+++ b/rust/tpde-llvm/src/lib.rs
@@ -8,17 +8,19 @@
 //! design and current limitations lives in [`tpde_core::overview`].
 
 use inkwell::module::Module;
-use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::CompilerBase};
+use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::{CompilerBase, Backend}};
 
 /// Compile an LLVM `Module` using a TPDE compiler setup.
-pub fn compile_ir<A, ASM>(
+pub fn compile_ir<A, ASM, C>(
     _module: &Module,
     _adaptor: A,
     _assembler: ASM,
-) -> CompilerBase<A, ASM>
+    _backend: C,
+) -> CompilerBase<A, ASM, C>
 where
     A: IrAdaptor,
     ASM: Assembler<A>,
+    C: Backend<A, ASM>,
 {
     unimplemented!("LLVM compilation not yet implemented")
 }


### PR DESCRIPTION
## Summary
- introduce `Backend` trait to drive instruction selection
- expose new assembler methods for finalization and output
- provide block/inst iteration on the `IrAdaptor`
- wire up `CompilerBase` to use the backend hooks

## Testing
- `cargo check --offline`

------
https://chatgpt.com/codex/tasks/task_e_683e226b5d2483268ee8697c019ef919