### PR TITLE
Add object based ElfAssembler with tests

### DIFF
--- a/rust/tpde-core/src/assembler.rs
+++ b/rust/tpde-core/src/assembler.rs
@@ -22,3 +22,145 @@ pub trait Assembler<A: IrAdaptor> {
     fn sym_predef_func(&mut self, name: &str, local: bool, weak: bool) -> Self::SymRef;
     fn sym_add_undef(&mut self, name: &str, local: bool, weak: bool);
 }
+
+use object::write::{Object, SectionId, StandardSection, SymbolId, Symbol, SymbolSection, SymbolScope, SymbolKind};
+use std::collections::HashMap;
+use object::{BinaryFormat, Architecture, Endianness};
+
+/// Label identifier used by [`ElfAssembler`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ElfLabel(usize);
+
+#[derive(Debug)]
+struct LabelInfo {
+    section: SectionId,
+    offset: Option<u64>,
+}
+
+/// Minimal assembler based on the [`object`] crate producing ELF objects.
+pub struct ElfAssembler {
+    obj: Object<'static>,
+    current: SectionId,
+    labels: Vec<LabelInfo>,
+    offsets: HashMap<SectionId, u64>,
+    _emit_obj: bool,
+}
+
+impl ElfAssembler {
+    /// Create a new section returning its identifier.
+    pub fn add_section(&mut self, name: &str, kind: object::SectionKind) -> SectionId {
+        let id = self.obj.add_section(Vec::new(), name.as_bytes().to_vec(), kind);
+        self.offsets.insert(id, 0);
+        id
+    }
+
+    /// Switch the current section.
+    pub fn switch_section(&mut self, id: SectionId) {
+        self.current = id;
+    }
+
+    /// Returns the current section identifier.
+    pub fn current_section(&self) -> SectionId {
+        self.current
+    }
+
+    /// Append data to the current section and return the offset.
+    pub fn append(&mut self, data: &[u8], align: u64) -> u64 {
+        let off = self.obj.append_section_data(self.current, data, align);
+        let end = off + data.len() as u64;
+        let entry = self.offsets.entry(self.current).or_insert(0);
+        if *entry < end {
+            *entry = end;
+        }
+        off
+    }
+
+    /// Finalize the object and return the binary.
+    pub fn build_object(self) -> Vec<u8> {
+        self.obj.write().expect("emit object")
+    }
+
+    /// Update a symbol to point at a location within a section.
+    pub fn define_symbol(&mut self, sym: SymbolId, section: SectionId, offset: u64, size: u64) {
+        let symbol = self.obj.symbol_mut(sym);
+        symbol.section = SymbolSection::Section(section);
+        symbol.value = offset;
+        symbol.size = size;
+    }
+
+    fn current_offset(&self) -> u64 {
+        *self.offsets.get(&self.current).unwrap_or(&0)
+    }
+
+    /// Get the offset of a label if placed.
+    pub fn label_offset(&self, label: ElfLabel) -> Option<u64> {
+        self.labels.get(label.0).and_then(|l| l.offset)
+    }
+
+    /// Return true if the label has not been placed yet.
+    pub fn label_is_pending(&self, label: ElfLabel) -> bool {
+        self.labels.get(label.0).map_or(false, |l| l.offset.is_none())
+    }
+}
+
+impl<A: IrAdaptor> Assembler<A> for ElfAssembler {
+    type SymRef = SymbolId;
+    type Label = ElfLabel;
+
+    fn new(generate_object: bool) -> Self {
+        let mut obj = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+        let text = obj.section_id(StandardSection::Text);
+        let mut offsets = HashMap::new();
+        offsets.insert(text, 0);
+        Self {
+            obj,
+            current: text,
+            labels: Vec::new(),
+            offsets,
+            _emit_obj: generate_object,
+        }
+    }
+
+    fn label_create(&mut self) -> Self::Label {
+        let id = self.labels.len();
+        self.labels.push(LabelInfo { section: self.current, offset: None });
+        ElfLabel(id)
+    }
+
+    fn label_place(&mut self, label: Self::Label) {
+        let offset = self.current_offset();
+        if let Some(info) = self.labels.get_mut(label.0) {
+            info.section = self.current;
+            info.offset = Some(offset);
+        }
+    }
+
+    fn sym_predef_func(&mut self, name: &str, local: bool, weak: bool) -> Self::SymRef {
+        let scope = if local { SymbolScope::Compilation } else { SymbolScope::Linkage };
+        self.obj.add_symbol(Symbol {
+            name: name.as_bytes().to_vec(),
+            value: 0,
+            size: 0,
+            kind: SymbolKind::Text,
+            scope,
+            weak,
+            section: SymbolSection::Undefined,
+            flags: object::write::SymbolFlags::None,
+        })
+    }
+
+    fn sym_add_undef(&mut self, name: &str, local: bool, weak: bool) {
+        let scope = if local { SymbolScope::Compilation } else { SymbolScope::Linkage };
+        self.obj.add_symbol(Symbol {
+            name: name.as_bytes().to_vec(),
+            value: 0,
+            size: 0,
+            kind: SymbolKind::Unknown,
+            scope,
+            weak,
+            section: SymbolSection::Undefined,
+            flags: object::write::SymbolFlags::None,
+        });
+    }
+}
+

--- a/rust/tpde-core/src/overview.rs
+++ b/rust/tpde-core/src/overview.rs
@@ -16,7 +16,7 @@
 //! 7. **Snippet Encoders** – optional helpers generated from high level code to
 //!    reduce manual instruction selection.
 //!
-//! ```
+//! ```text
 //! ┌───────────┐      ┌───────────────────────────┐     ┌───────────┐
 //! │           │◄─────┼                           ├────►│           │
 //! │ IRAdaptor │      │     CompilerBase          │     │ Assembler │

--- a/rust/tpde-core/tests/elf_assembler.rs
+++ b/rust/tpde-core/tests/elf_assembler.rs
@@ -1,0 +1,38 @@
+use tpde_core::adaptor::IrAdaptor;
+use tpde_core::assembler::{Assembler, ElfAssembler};
+use object::{File, Object};
+
+struct DummyAdaptor;
+
+impl IrAdaptor for DummyAdaptor {
+    type ValueRef = ();
+    type InstRef = ();
+    type BlockRef = ();
+    type FuncRef = ();
+
+    const INVALID_VALUE_REF: Self::ValueRef = ();
+    const INVALID_BLOCK_REF: Self::BlockRef = ();
+    const INVALID_FUNC_REF: Self::FuncRef = ();
+
+    fn func_count(&self) -> u32 { 0 }
+    fn funcs(&self) -> Box<dyn Iterator<Item = Self::FuncRef> + '_> { Box::new(std::iter::empty()) }
+    fn func_link_name(&self, _f: Self::FuncRef) -> &str { "" }
+    fn switch_func(&mut self, _f: Self::FuncRef) -> bool { false }
+    fn reset(&mut self) {}
+}
+
+#[test]
+fn simple_object() {
+    let mut asm = <ElfAssembler as Assembler<DummyAdaptor>>::new(true);
+    let lbl = <ElfAssembler as Assembler<DummyAdaptor>>::label_create(&mut asm);
+    <ElfAssembler as Assembler<DummyAdaptor>>::label_place(&mut asm, lbl);
+    asm.append(&[0xC3], 1); // ret
+    let sym = <ElfAssembler as Assembler<DummyAdaptor>>::sym_predef_func(&mut asm, "foo", false, false);
+    let off = asm.label_offset(lbl).unwrap();
+    let sec = asm.current_section();
+    asm.define_symbol(sym, sec, off, 1);
+    let obj = asm.build_object();
+    let file = File::parse(&*obj).unwrap();
+    assert!(file.section_by_name(".text").is_some());
+    assert!(file.symbol_by_name("foo").is_some());
+}


### PR DESCRIPTION
## Summary
- implement `ElfAssembler` using the object crate
- expose helpers to manage sections and symbols
- add a unit test building a tiny ELF object
- fix docs in overview to avoid doctest failures

## Testing
- `cargo test -p tpde-core --offline`

------
https://chatgpt.com/codex/tasks/task_e_683e226a3bdc83269713a657c96b7ba7