### PR TITLE
Add basic encode generator

### DIFF
--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,8 +1,42 @@
 /// CLI entry point for snippet encoder generation.
 ///
-/// At the moment this only prints a placeholder message.  The real work is done
-/// in [`tpde_encodegen::generate`].  See [`tpde_core::overview`] for an
-/// overview of the intended workflow.
+/// This parses an LLVM IR file and writes the generated Rust snippets
+/// to the provided output path. If no output is specified the snippets
+/// are printed to stdout.
+use std::{env, fs};
+
+use inkwell::context::Context;
+
+fn usage() {
+    eprintln!("usage: tpde-encodegen <input.ll> [output.rs]");
+}
+
 fn main() {
-    println!("tpde-encodegen placeholder");
+    let mut args = env::args().skip(1);
+    let input = match args.next() {
+        Some(p) => p,
+        None => {
+            usage();
+            return;
+        }
+    };
+    let output = args.next();
+
+    let ir = fs::read_to_string(&input).expect("failed to read input");
+    let context = Context::create();
+    let tokens = match tpde_encodegen::parse_and_generate(&context, &ir) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("parse error: {}", e);
+            return;
+        }
+    };
+
+    if let Some(out) = output {
+        fs::write(out, tokens.join("\n")).expect("failed to write output");
+    } else {
+        for t in tokens {
+            println!("{}", t);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement parsing of text LLVM IR using inkwell
- generate stub Rust functions for `pattern_` prefixed IR functions
- expose CLI that writes tokens to file or stdout
- improve CLI usage handling and add docs

## Testing
- `cargo check --all-targets --workspace --offline`


------
https://chatgpt.com/codex/tasks/task_e_683e226c55408326b33d234b9fe918d0