### PR TITLE
Add extensible backend hooks

### DIFF
--- a/rust/tpde-core/src/adaptor.rs
+++ b/rust/tpde-core/src/adaptor.rs
@@ -14,7 +14,8 @@
 //! - Queries for function count and iteration.
 //! - Methods to fetch linkage names, switch functions and reset between runs.
 //!
-//! More features like operand access will be added as the runtime expands.
+//! Methods for operand access and block iteration are expected to grow over time
+//! as the runtime expands.
 //! Implementations may preprocess data in `switch_func` to speed up later calls.
 
 /// Bridge between an SSA IR and TPDE.
@@ -49,4 +50,27 @@ pub trait IrAdaptor {
 
     /// Reset internal state between compilation runs.
     fn reset(&mut self);
+
+    /// Iterator over blocks in the current function.
+    ///
+    /// ```no_run
+    /// # use tpde_core::guide;
+    /// # let mut adaptor = unimplemented!("see guide for an example adaptor");
+    /// adaptor.switch_func(adaptor.funcs().next().unwrap());
+    /// for block in adaptor.blocks() {
+    ///     for inst in adaptor.block_insts(block) {
+    ///         let _ = adaptor.inst_operands(inst).count();
+    ///     }
+    /// }
+    /// ```
+    fn blocks(&self) -> Box<dyn Iterator<Item = Self::BlockRef> + '_>;
+
+    /// Iterator over instructions of the given block.
+    fn block_insts(&self, block: Self::BlockRef) -> Box<dyn Iterator<Item = Self::InstRef> + '_>;
+
+    /// Iterator over the operands of an instruction.
+    fn inst_operands(&self, inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_>;
+
+    /// Iterator over the result values produced by an instruction.
+    fn inst_results(&self, inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_>;
 }

--- a/rust/tpde-core/src/assembler.rs
+++ b/rust/tpde-core/src/assembler.rs
@@ -21,4 +21,17 @@ pub trait Assembler<A: IrAdaptor> {
 
     fn sym_predef_func(&mut self, name: &str, local: bool, weak: bool) -> Self::SymRef;
     fn sym_add_undef(&mut self, name: &str, local: bool, weak: bool);
+
+    /// Finalize sections and relocations after code generation.
+    fn finalize(&mut self);
+
+    /// Write a finished object file to a byte vector.
+    fn build_object_file(&mut self) -> Vec<u8>;
+
+    /// Map the generated code into memory for JIT execution.
+    ///
+    /// `resolve` should return the address of any unresolved symbol.
+    fn map<F>(&mut self, resolve: F) -> bool
+    where
+        F: FnMut(&str) -> *const u8;
 }

--- a/rust/tpde-core/src/compiler.rs
+++ b/rust/tpde-core/src/compiler.rs
@@ -35,6 +35,23 @@
 
 use crate::{adaptor::IrAdaptor, analyzer::Analyzer, assembler::Assembler};
 
+/// Hooks implemented by architecture specific compiler code.
+///
+/// The `Backend` drives instruction selection and can emit a prologue
+/// and epilogue around each function.  Methods receive a mutable reference
+/// to the [`CompilerBase`] so they can use register allocation helpers.
+pub trait Backend<A: IrAdaptor, ASM: Assembler<A>> {
+    fn gen_prologue(&mut self, base: &mut CompilerBase<A, ASM, Self>) where Self: Sized;
+    fn gen_epilogue(&mut self, base: &mut CompilerBase<A, ASM, Self>) where Self: Sized;
+    fn compile_inst(
+        &mut self,
+        base: &mut CompilerBase<A, ASM, Self>,
+        inst: A::InstRef,
+    ) -> bool
+    where
+        Self: Sized;
+}
+
 /// Architecture independent compiler driver.
 ///
 /// [`CompilerBase`] coordinates the entire compilation pipeline described in the
@@ -44,19 +61,26 @@ use crate::{adaptor::IrAdaptor, analyzer::Analyzer, assembler::Assembler};
 /// an [`Assembler`].  Register allocation happens on the fly based on the
 /// liveness info.  This file only implements a thin skeleton so far.
 #[allow(dead_code)]
-pub struct CompilerBase<A: IrAdaptor, ASM: Assembler<A>> {
+pub struct CompilerBase<A: IrAdaptor, ASM: Assembler<A>, C: Backend<A, ASM>> {
     adaptor: A,
     analyzer: Analyzer<A>,
     assembler: ASM,
+    backend: C,
 }
 
-impl<A: IrAdaptor, ASM: Assembler<A>> CompilerBase<A, ASM> {
-    /// Create a new compiler base from an adaptor and assembler.
-    pub fn new(adaptor: A, assembler: ASM) -> Self {
+impl<A, ASM, C> CompilerBase<A, ASM, C>
+where
+    A: IrAdaptor,
+    ASM: Assembler<A>,
+    C: Backend<A, ASM>,
+{
+    /// Create a new compiler base from an adaptor, assembler and backend.
+    pub fn new(adaptor: A, assembler: ASM, backend: C) -> Self {
         Self {
             adaptor,
             analyzer: Analyzer::new(),
             assembler,
+            backend,
         }
     }
 
@@ -68,8 +92,26 @@ impl<A: IrAdaptor, ASM: Assembler<A>> CompilerBase<A, ASM> {
                 continue;
             }
             self.analyzer.switch_func(&mut self.adaptor, func);
-            // architecture specific code generation would go here
+
+            // Using a raw pointer avoids borrow checker conflicts between the
+            // backend and the base structure.
+            let base_ptr: *mut Self = self;
+            let backend = &mut self.backend;
+            unsafe { backend.gen_prologue(&mut *base_ptr) };
+
+            for block in self.adaptor.blocks() {
+                for inst in self.adaptor.block_insts(block) {
+                    let ok = unsafe { backend.compile_inst(&mut *base_ptr, inst) };
+                    if !ok {
+                        return false;
+                    }
+                }
+            }
+
+            unsafe { backend.gen_epilogue(&mut *base_ptr) };
         }
+
+        self.assembler.finalize();
         true
     }
 }

--- a/rust/tpde-core/src/lib.rs
+++ b/rust/tpde-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod adaptor;
 pub mod analyzer;
 pub mod assembler;
 pub mod compiler;
+pub use compiler::{Backend, CompilerBase};
 
 /// Temporary hello world to prove the crate builds.
 pub fn hello() -> &'static str {

--- a/rust/tpde-core/src/overview.rs
+++ b/rust/tpde-core/src/overview.rs
@@ -50,6 +50,8 @@
 //!   instructions and managing register allocation.
 //! - The assembler collects sections, relocations and unwind data and finally
 //!   writes an ELF object or maps the code into memory.
+//! - Users implement [`Backend`] to drive instruction selection and emit
+//!   prologue/epilogue code for each function.
 //!
 //! TPDE is intended for baseline code generation. It trades heavy
 //! optimization passes for very fast compile times while still delivering

--- a/rust/tpde-encodegen/src/lib.rs
+++ b/rust/tpde-encodegen/src/lib.rs
@@ -10,8 +10,10 @@
 
 use inkwell::module::Module;
 
-/// Parse the provided LLVM IR module and emit snippet encoders.
-#[allow(dead_code)]
-pub fn generate(_module: &Module) {
-    todo!("encode generation not yet implemented")
+/// Generate snippet encoder source from the provided LLVM IR `Module`.
+///
+/// The current implementation simply returns a placeholder string.  Real
+/// logic will analyse the IR and emit encoder functions.
+pub fn generate(_module: &Module) -> String {
+    "// encode generation not yet implemented\n".to_string()
 }

--- a/rust/tpde-encodegen/src/main.rs
+++ b/rust/tpde-encodegen/src/main.rs
@@ -1,8 +1,84 @@
 /// CLI entry point for snippet encoder generation.
 ///
-/// At the moment this only prints a placeholder message.  The real work is done
-/// in [`tpde_encodegen::generate`].  See [`tpde_core::overview`] for an
-/// overview of the intended workflow.
-fn main() {
-    println!("tpde-encodegen placeholder");
+/// The program expects an input LLVM IR file and optionally an output file
+/// passed via `-o` or `--output`.  The generated source is written to stdout
+/// when no output file is specified.
+use std::{env, fs::File, io::{self, Read, Write}, process::exit};
+
+use inkwell::{context::Context, memory_buffer::MemoryBuffer};
+
+fn print_help(program: &str) {
+    println!(
+        "Usage: {program} <input> [-o <output>]\n\n\
+Generate snippet encoders from LLVM IR.  Output defaults to stdout." );
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = None;
+    let mut output = None;
+
+    let mut args = env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-o" | "--output" => {
+                output = args.next();
+                if output.is_none() {
+                    eprintln!("missing argument for {}", arg);
+                    let prog = env::args().next().unwrap_or_default();
+                    print_help(&prog);
+                    exit(1);
+                }
+            }
+            "-h" | "--help" => {
+                let prog = env::args().next().unwrap_or_default();
+                print_help(&prog);
+                return Ok(());
+            }
+            _ => {
+                if input.is_none() {
+                    input = Some(arg);
+                } else {
+                    eprintln!("unexpected argument: {}", arg);
+                    let prog = env::args().next().unwrap_or_default();
+                    print_help(&prog);
+                    exit(1);
+                }
+            }
+        }
+    }
+
+    let prog = env::args().next().unwrap_or_else(|| "tpde-encodegen".into());
+    let input_path = match input {
+        Some(p) => p,
+        None => {
+            print_help(&prog);
+            exit(1);
+        }
+    };
+
+    let ir = {
+        let mut buf = Vec::new();
+        File::open(&input_path)?.read_to_end(&mut buf)?;
+        buf
+    };
+
+    let context = Context::create();
+    let buffer = MemoryBuffer::create_from_memory_range_copy(&ir, &input_path);
+    let module = context
+        .create_module_from_ir(buffer)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+    let generated = tpde_encodegen::generate(&module);
+
+    match output {
+        Some(path) => {
+            let mut file = File::create(path)?;
+            file.write_all(generated.as_bytes())?;
+        }
+        None => {
+            io::stdout().write_all(generated.as_bytes())?;
+        }
+    }
+
+    Ok(())
 }

--- a/rust/tpde-llvm/src/lib.rs
+++ b/rust/tpde-llvm/src/lib.rs
@@ -7,20 +7,159 @@
 //! handled by falling back to LLVM.  A condensed description of the original
 //! design and current limitations lives in [`tpde_core::overview`].
 
-use inkwell::module::Module;
-use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::CompilerBase};
+use inkwell::{
+    basic_block::BasicBlock,
+    module::Module,
+    values::{BasicValueEnum, FunctionValue, InstructionValue},
+};
+use tpde_core::{adaptor::IrAdaptor, assembler::Assembler, compiler::{CompilerBase, Backend}};
 
-/// Compile an LLVM `Module` using a TPDE compiler setup.
-pub fn compile_ir<A, ASM>(
-    _module: &Module,
-    _adaptor: A,
-    _assembler: ASM,
-) -> CompilerBase<A, ASM>
+/// Adaptor walking an LLVM [`Module`] using `inkwell`.
+///
+/// This very small implementation only exposes functions which is enough for
+/// [`CompilerBase::compile`].  Values, blocks and instructions are represented
+/// as `Option` types so we can define an invalid constant.
+pub struct LlvmIrAdaptor<'ctx> {
+    module: Module<'ctx>,
+    funcs: Vec<FunctionValue<'ctx>>,
+    names: Vec<String>,
+    current: Option<FunctionValue<'ctx>>,
+}
+
+impl<'ctx> LlvmIrAdaptor<'ctx> {
+    /// Create a new adaptor collecting all functions in the module.
+    pub fn new(module: &Module<'ctx>) -> Self {
+        let funcs: Vec<_> = module.get_functions().collect();
+        let names = funcs
+            .iter()
+            .map(|f| f.get_name().to_str().unwrap_or("").to_string())
+            .collect();
+        Self {
+            module: module.clone(),
+            funcs,
+            names,
+            current: None,
+        }
+    }
+}
+
+impl<'ctx> IrAdaptor for LlvmIrAdaptor<'ctx> {
+    type ValueRef = Option<BasicValueEnum<'ctx>>;
+    type InstRef = Option<InstructionValue<'ctx>>;
+    type BlockRef = Option<BasicBlock<'ctx>>;
+    type FuncRef = Option<FunctionValue<'ctx>>;
+
+    const INVALID_VALUE_REF: Self::ValueRef = None;
+    const INVALID_BLOCK_REF: Self::BlockRef = None;
+    const INVALID_FUNC_REF: Self::FuncRef = None;
+
+    fn func_count(&self) -> u32 {
+        self.funcs.len() as u32
+    }
+
+    fn funcs(&self) -> Box<dyn Iterator<Item = Self::FuncRef> + '_> {
+        Box::new(self.funcs.iter().cloned().map(Some))
+    }
+
+    fn func_link_name(&self, func: Self::FuncRef) -> &str {
+        if let Some(f) = func {
+            if let Some(pos) = self.funcs.iter().position(|&fv| fv == f) {
+                return &self.names[pos];
+            }
+        }
+        ""
+    }
+
+    fn switch_func(&mut self, func: Self::FuncRef) -> bool {
+        self.current = func;
+        func.is_some()
+    }
+
+    fn reset(&mut self) {
+        self.current = None;
+    }
+
+    fn blocks(&self) -> Box<dyn Iterator<Item = Self::BlockRef> + '_> {
+        if let Some(func) = self.current {
+            Box::new(func.get_basic_blocks().into_iter().map(Some))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+
+    fn block_insts(&self, block: Self::BlockRef) -> Box<dyn Iterator<Item = Self::InstRef> + '_> {
+        if let Some(bb) = block {
+            Box::new(bb.get_instructions().into_iter().map(Some))
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+
+    fn inst_operands(&self, inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_> {
+        let _ = inst;
+        Box::new(std::iter::empty())
+    }
+
+    fn inst_results(&self, _inst: Self::InstRef) -> Box<dyn Iterator<Item = Self::ValueRef> + '_> {
+        Box::new(std::iter::empty())
+    }
+}
+
+/// Minimal assembler that satisfies [`Assembler`].
+pub struct NullAssembler {
+    next_label: usize,
+}
+
+impl NullAssembler {
+    pub fn new(_: bool) -> Self {
+        Self { next_label: 0 }
+    }
+}
+
+impl<A: IrAdaptor> Assembler<A> for NullAssembler {
+    type SymRef = ();
+    type Label = usize;
+
+    fn new(generate_object: bool) -> Self {
+        Self::new(generate_object)
+    }
+
+    fn label_create(&mut self) -> Self::Label {
+        let id = self.next_label;
+        self.next_label += 1;
+        id
+    }
+
+    fn label_place(&mut self, _label: Self::Label) {}
+
+    fn sym_predef_func(&mut self, _name: &str, _local: bool, _weak: bool) -> Self::SymRef {}
+
+    fn sym_add_undef(&mut self, _name: &str, _local: bool, _weak: bool) {}
+
+    fn finalize(&mut self) {}
+
+    fn build_object_file(&mut self) -> Vec<u8> { Vec::new() }
+
+    fn map<F>(&mut self, _resolve: F) -> bool
+    where
+        F: FnMut(&str) -> *const u8,
+    {
+        true
+    }
+}
+
+/// Build a [`CompilerBase`] ready to process the LLVM `Module`.
+///
+/// The returned compiler can immediately run [`CompilerBase::compile`].  The
+/// current implementation only gathers functions; instruction selection is
+/// still a stub.
+pub fn compile_ir<'ctx, B>(module: &Module<'ctx>, backend: B) -> CompilerBase<LlvmIrAdaptor<'ctx>, NullAssembler, B>
 where
-    A: IrAdaptor,
-    ASM: Assembler<A>,
+    B: Backend<LlvmIrAdaptor<'ctx>, NullAssembler>,
 {
-    unimplemented!("LLVM compilation not yet implemented")
+    let adaptor = LlvmIrAdaptor::new(module);
+    let assembler = NullAssembler::new(false);
+    CompilerBase::new(adaptor, assembler, backend)
 }
 
 /// Simple text marker proving the crate works.


### PR DESCRIPTION
## Summary
- introduce `Backend` trait to drive instruction selection
- expose new assembler methods for finalization and output
- provide block/inst iteration on the `IrAdaptor`
- wire up `CompilerBase` to use the backend hooks
- merge latest upstream changes and fix build

## Testing
- `cargo check --all --offline`

------
https://chatgpt.com/codex/tasks/task_e_683e226b5d2483268ee8697c019ef919