### PR TITLE
Allocate analysis vectors from arena

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.16", features = ["allocator-api2", "collections"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
- allocate intermediate vectors in `FunctionAnalyzer` using bumpalo arena
- enable bumpalo `collections` feature so BumpVec is available

## Testing
- `cargo check --offline`
- `cargo test --offline`


------
https://chatgpt.com/codex/tasks/task_e_68442b8c86588326ba154843613641da