### PR TITLE
Allocate calling convention assignments from arena

### DIFF
--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -429,11 +429,15 @@ where
         };
 
         // Setup calling convention
-        self.codegen.process_arguments(&args_vec).map_err(|e| {
+        self.codegen
+            .process_arguments(self.session, &args_vec)
+            .map_err(|e| {
             LlvmCompilerError::CodeGeneration(format!("Argument processing failed: {:?}", e))
         })?;
 
-        self.codegen.process_return_values(&ret_info).map_err(|e| {
+        self.codegen
+            .process_return_values(self.session, &ret_info)
+            .map_err(|e| {
             LlvmCompilerError::CodeGeneration(format!("Return value processing failed: {:?}", e))
         })?;
 

--- a/rust/src/test_ir/compiler.rs
+++ b/rust/src/test_ir/compiler.rs
@@ -118,7 +118,7 @@ impl<'arena> TestIRCompiler<'arena> {
             func.name, arg_count, func.arg_begin_idx, func.arg_end_idx
         );
         let args: Vec<ArgInfo> = vec![ArgInfo::int64(); arg_count];
-        let arg_assignments = func_codegen.process_arguments(&args)?;
+        let arg_assignments = func_codegen.process_arguments(self._session, &args)?;
 
         // Assign arguments to registers/stack according to calling convention
         for (idx, assignment) in arg_assignments.iter().enumerate() {
@@ -158,7 +158,7 @@ impl<'arena> TestIRCompiler<'arena> {
 
         // Set return value (always single i64 for TestIR)
         let rets = vec![ArgInfo::int64()];
-        func_codegen.process_return_values(&rets)?;
+        func_codegen.process_return_values(self._session, &rets)?;
 
         // Generate prologue
         func_codegen.emit_prologue()?;


### PR DESCRIPTION
## Summary
- store temporary argument and return assignments in the session arena
- update LLVM and TestIR compilers for the new API
- adapt unit tests

## Testing
- `cargo test --all --offline` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68442b88f438832688343f3eaea7b0d2