### PR TITLE
Improve SysV assigner and call tests

### DIFF
--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -2971,7 +2971,6 @@ where
 
         // Process arguments and assign them according to System V ABI
         let mut arg_assignments = Vec::new();
-        let mut xmm_count_for_varargs = 0u8;
 
         for i in 0..arg_count {
             let arg_value = instruction.get_operand(i).unwrap().left().unwrap();
@@ -3029,11 +3028,6 @@ where
             let mut assignment = CCAssignment::with_attribute(bank, size, align, final_attr);
             cc_assigner.assign_arg(&mut assignment);
 
-            // Track XMM register usage for varargs
-            if is_varargs && i < fixed_arg_count && bank == RegBank::Xmm && assignment.reg.is_some()
-            {
-                xmm_count_for_varargs += 1;
-            }
 
             log::debug!(
                 "   Arg {}: v{} -> {:?} (attr: {:?})",
@@ -3188,19 +3182,22 @@ where
             }
         }
 
-        // For varargs functions, set AL register with XMM count
-        if is_varargs && xmm_count_for_varargs > 0 {
-            let encoder = self.codegen.encoder_mut();
-            let al = AsmReg::new(0, 0); // AL register
-            encoder
-                .mov_reg_imm(al, xmm_count_for_varargs as i64)
-                .map_err(|e| {
-                    LlvmCompilerError::CodeGeneration(format!(
-                        "Failed to set AL for varargs: {:?}",
-                        e
-                    ))
-                })?;
-            log::trace!("   Set AL={} for varargs XMM count", xmm_count_for_varargs);
+        // For varargs functions, set AL register with XMM register count
+        if is_varargs {
+            let used_xmm = cc_assigner.xmm_used();
+            if used_xmm > 0 {
+                let encoder = self.codegen.encoder_mut();
+                let al = AsmReg::new(0, 0); // AL register
+                encoder
+                    .mov_reg_imm(al, used_xmm as i64)
+                    .map_err(|e| {
+                        LlvmCompilerError::CodeGeneration(format!(
+                            "Failed to set AL for varargs: {:?}",
+                            e
+                        ))
+                    })?;
+                log::trace!("   Set AL={} for varargs XMM count", used_xmm);
+            }
         }
 
         // Emit the actual call instruction

--- a/rust/src/x64/calling_convention.rs
+++ b/rust/src/x64/calling_convention.rs
@@ -232,6 +232,16 @@ impl SysVAssigner {
         self.must_assign_stack = true;
     }
 
+    /// Number of GP argument registers used so far.
+    pub fn gp_used(&self) -> usize {
+        self.gp_cnt
+    }
+
+    /// Number of XMM argument registers used so far.
+    pub fn xmm_used(&self) -> usize {
+        self.xmm_cnt
+    }
+
     /// Align a value up to the specified alignment.
     fn align_up(value: u32, align: u32) -> u32 {
         (value + align - 1) & !(align - 1)


### PR DESCRIPTION
## Summary
- enhance SysV assigner with helpers for GP/XMM register counts
- use the counts when setting AL for vararg calls
- extend sret test module with a caller
- update integration tests for byval, sret and varargs

## Testing
- `cargo test --offline`

------
https://chatgpt.com/codex/tasks/task_e_68442a2f73748326892b6af8728ed1f9