### PR TITLE
Use bump-allocated maps in session

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,8 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.18", features = ["allocator-api2", "collections"] }
+hashbrown = "0.15"
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -233,10 +233,7 @@ impl std::fmt::Display for LlvmCompilerError {
 
 impl std::error::Error for LlvmCompilerError {}
 
-impl<'ctx, 'arena> LlvmCompiler<'ctx, 'arena>
-where
-    'ctx: 'arena,
-{
+impl<'ctx, 'arena> LlvmCompiler<'ctx, 'arena> {
     /// Create a new LLVM compiler.
     pub fn new(
         module: inkwell::module::Module<'ctx>,
@@ -3377,7 +3374,7 @@ where
     ) -> Result<(), LlvmCompilerError> {
         // Store each PHI node in the session
         for phi_node in &analysis.phi_nodes[0..analysis.phi_count] {
-            let mut incoming_values = Vec::new();
+            let mut incoming_values = bumpalo::collections::Vec::new_in(self.session.arena());
 
             // Collect incoming values for this PHI
             for i in 0..phi_node.incoming_count {


### PR DESCRIPTION
## Summary
- swap to `hashbrown::HashMap` with bump allocation in the session
- allocate block/phi info vectors and interned strings from the arena
- tweak LLVM compiler to work with the new API
- enable bumpalo `collections` and add `hashbrown`

## Testing
- `cargo test --workspace --offline` *(fails: could not compile `tpde`)*

------
https://chatgpt.com/codex/tasks/task_e_68442b84d33c8326b36b798bdb7bf7d1