### PR TITLE
Use arena Vecs for value assignments

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.16", features = ["allocator-api2", "collections"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/core/value_ref.rs
+++ b/rust/src/core/value_ref.rs
@@ -51,14 +51,14 @@ pub enum OwnershipMode {
 ///
 /// This allows ValueRef and ValuePartRef to access the necessary systems
 /// without holding direct references, avoiding Rust borrowing conflicts.
-pub struct CompilerContext<'a> {
-    pub assignments: &'a mut ValueAssignmentManager,
+pub struct CompilerContext<'a, 'arena> {
+    pub assignments: &'a mut ValueAssignmentManager<'arena>,
     pub register_file: &'a mut RegisterFile,
 }
 
-impl<'a> CompilerContext<'a> {
+impl<'a, 'arena> CompilerContext<'a, 'arena> {
     pub fn new(
-        assignments: &'a mut ValueAssignmentManager,
+        assignments: &'a mut ValueAssignmentManager<'arena>,
         register_file: &'a mut RegisterFile,
     ) -> Self {
         Self {
@@ -87,7 +87,7 @@ impl ValueRef {
     pub fn new(
         local_idx: ValLocalIdx,
         ownership: OwnershipMode,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, '_>,
     ) -> Self {
         // Add reference count if using ref-counted ownership
         if ownership == OwnershipMode::RefCounted {
@@ -104,7 +104,7 @@ impl ValueRef {
     }
 
     /// Create an owned ValueRef (takes exclusive ownership).
-    pub fn owned(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> Self {
+    pub fn owned(local_idx: ValLocalIdx, ctx: &mut CompilerContext<'_, '_>) -> Self {
         // For owned values, we need to add a reference that we'll remove on drop
         if let Some(assignment) = ctx.assignments.get_assignment_mut(local_idx) {
             assignment.add_ref();
@@ -118,7 +118,7 @@ impl ValueRef {
     }
 
     /// Create a ref-counted ValueRef (shared ownership).
-    pub fn ref_counted(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> Self {
+    pub fn ref_counted(local_idx: ValLocalIdx, ctx: &mut CompilerContext<'_, '_>) -> Self {
         Self::new(local_idx, OwnershipMode::RefCounted, ctx)
     }
 
@@ -128,7 +128,7 @@ impl ValueRef {
     }
 
     /// Get the number of parts for this value.
-    pub fn part_count(&self, ctx: &CompilerContext) -> Result<u32, ValueRefError> {
+    pub fn part_count(&self, ctx: &CompilerContext<'_, '_>) -> Result<u32, ValueRefError> {
         ctx.assignments
             .get_assignment(self.local_idx)
             .map(|a| a.part_count)
@@ -139,7 +139,7 @@ impl ValueRef {
     pub fn part(
         &self,
         part_idx: u32,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, '_>,
     ) -> Result<ValuePartRef, ValueRefError> {
         let part_count = self.part_count(ctx)?;
         if part_idx >= part_count {
@@ -150,12 +150,12 @@ impl ValueRef {
     }
 
     /// Access the first (and usually only) part of this value.
-    pub fn single_part(&self, ctx: &mut CompilerContext) -> Result<ValuePartRef, ValueRefError> {
+    pub fn single_part(&self, ctx: &mut CompilerContext<'_, '_>) -> Result<ValuePartRef, ValueRefError> {
         self.part(0, ctx)
     }
 
     /// Check if this value is currently assigned to a register.
-    pub fn is_in_register(&self, part_idx: u32, ctx: &CompilerContext) -> bool {
+    pub fn is_in_register(&self, part_idx: u32, ctx: &CompilerContext<'_, '_>) -> bool {
         if let Some(assignment) = ctx.assignments.get_assignment(self.local_idx) {
             if let Some(part_data) = assignment.part(part_idx) {
                 return part_data.register_valid();
@@ -165,7 +165,7 @@ impl ValueRef {
     }
 
     /// Get the register for a specific part if it's currently assigned.
-    pub fn current_register(&self, part_idx: u32, ctx: &CompilerContext) -> Option<AsmReg> {
+    pub fn current_register(&self, part_idx: u32, ctx: &CompilerContext<'_, '_>) -> Option<AsmReg> {
         if !self.is_in_register(part_idx, ctx) {
             return None;
         }
@@ -187,13 +187,13 @@ impl ValueRef {
     }
 
     /// Manually drop this ValueRef with access to the context.
-    pub fn drop_with_context(mut self, ctx: &mut CompilerContext) {
+    pub fn drop_with_context(mut self, ctx: &mut CompilerContext<'_, '_>) {
         self.cleanup(ctx);
         self.consumed = true; // Prevent double cleanup
     }
 
     /// Internal cleanup method.
-    fn cleanup(&mut self, ctx: &mut CompilerContext) {
+    fn cleanup(&mut self, ctx: &mut CompilerContext<'_, '_>) {
         if !self.consumed && self.ownership != OwnershipMode::Unowned {
             ctx.assignments.remove_ref(self.local_idx);
         }
@@ -236,7 +236,7 @@ impl ValuePartRef {
     /// This is the primary method used by instruction selection to get
     /// a register containing the value. It handles allocation, reloading
     /// from stack, and locking automatically.
-    pub fn load_to_reg(&mut self, ctx: &mut CompilerContext) -> Result<AsmReg, ValueRefError> {
+    pub fn load_to_reg(&mut self, ctx: &mut CompilerContext<'_, '_>) -> Result<AsmReg, ValueRefError> {
         log::trace!(
             "load_to_reg for local_idx={}, part_idx={}",
             self.local_idx,
@@ -260,7 +260,7 @@ impl ValuePartRef {
     }
 
     /// Allocate a register for this part.
-    fn allocate_register(&mut self, ctx: &mut CompilerContext) -> Result<AsmReg, ValueRefError> {
+    fn allocate_register(&mut self, ctx: &mut CompilerContext<'_, '_>) -> Result<AsmReg, ValueRefError> {
         log::trace!(
             "allocate_register for local_idx={}, part_idx={}",
             self.local_idx,
@@ -318,7 +318,7 @@ impl ValuePartRef {
     pub fn alloc_try_reuse(
         &mut self,
         other: &mut ValuePartRef,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, '_>,
     ) -> Result<AsmReg, ValueRefError> {
         if let Some(other_reg) = other.current_register(ctx) {
             // Check if we can take ownership of the other register
@@ -335,7 +335,7 @@ impl ValuePartRef {
     }
 
     /// Get the current register for this part (if any).
-    pub fn current_register(&self, ctx: &CompilerContext) -> Option<AsmReg> {
+    pub fn current_register(&self, ctx: &CompilerContext<'_, '_>) -> Option<AsmReg> {
         ctx.assignments
             .get_assignment(self.local_idx)
             .and_then(|assignment| assignment.part(self.part_idx))
@@ -344,7 +344,7 @@ impl ValuePartRef {
     }
 
     /// Check if this part can transfer ownership of its register.
-    fn can_transfer_ownership(&self, ctx: &CompilerContext) -> bool {
+    fn can_transfer_ownership(&self, ctx: &CompilerContext<'_, '_>) -> bool {
         // Can transfer if we have exclusive access and the register isn't shared
         self.locked_register.is_some()
             && ctx
@@ -355,7 +355,7 @@ impl ValuePartRef {
     }
 
     /// Release ownership of the current register.
-    fn release_register(&mut self, ctx: &mut CompilerContext) -> Result<(), ValueRefError> {
+    fn release_register(&mut self, ctx: &mut CompilerContext<'_, '_>) -> Result<(), ValueRefError> {
         if let Some(reg) = self.locked_register.take() {
             // Unlock the register
             ctx.register_file
@@ -376,7 +376,7 @@ impl ValuePartRef {
     fn claim_register(
         &mut self,
         reg: AsmReg,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, '_>,
     ) -> Result<(), ValueRefError> {
         // Update our assignment
         if let Some(assignment) = ctx.assignments.get_assignment_mut(self.local_idx) {
@@ -400,7 +400,7 @@ impl ValuePartRef {
     }
 
     /// Mark this part as modified (dirty).
-    pub fn set_modified(&mut self, ctx: &mut CompilerContext) {
+    pub fn set_modified(&mut self, ctx: &mut CompilerContext<'_, '_>) {
         self.modified = true;
         if let Some(reg) = self.current_register(ctx) {
             ctx.register_file.mark_clobbered(reg);
@@ -413,7 +413,7 @@ impl ValuePartRef {
     }
 
     /// Spill this part to memory if it's in a register.
-    pub fn spill(&mut self, ctx: &mut CompilerContext) -> Result<(), ValueRefError> {
+    pub fn spill(&mut self, ctx: &mut CompilerContext<'_, '_>) -> Result<(), ValueRefError> {
         if let Some(_reg) = self.current_register(ctx) {
             // In a real implementation, this would generate spill code
             // For now, we just mark the register as invalid
@@ -427,7 +427,7 @@ impl ValuePartRef {
     }
 
     /// Get the size of this part in bytes.
-    pub fn size_bytes(&self, ctx: &CompilerContext) -> u32 {
+    pub fn size_bytes(&self, ctx: &CompilerContext<'_, '_>) -> u32 {
         ctx.assignments
             .get_assignment(self.local_idx)
             .and_then(|assignment| assignment.part(self.part_idx))
@@ -436,12 +436,12 @@ impl ValuePartRef {
     }
 
     /// Manually drop this ValuePartRef with access to the context.
-    pub fn drop_with_context(mut self, ctx: &mut CompilerContext) {
+    pub fn drop_with_context(mut self, ctx: &mut CompilerContext<'_, '_>) {
         self.cleanup(ctx);
     }
 
     /// Internal cleanup method.
-    fn cleanup(&mut self, ctx: &mut CompilerContext) {
+    fn cleanup(&mut self, ctx: &mut CompilerContext<'_, '_>) {
         // Unlock any locked register
         if let Some(reg) = self.locked_register {
             let _ = ctx.register_file.unlock_register(reg);
@@ -459,7 +459,7 @@ impl ValueRefBuilder {
     /// Create a ValueRef with ownership determined by liveness analysis.
     pub fn build_for_value(
         local_idx: ValLocalIdx,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, '_>,
         is_last_use: bool,
     ) -> ValueRef {
         let ownership = if is_last_use {
@@ -474,7 +474,7 @@ impl ValueRefBuilder {
     }
 
     /// Create a ValueRef for a result value (always owned).
-    pub fn build_for_result(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> ValueRef {
+    pub fn build_for_result(local_idx: ValLocalIdx, ctx: &mut CompilerContext<'_, '_>) -> ValueRef {
         ValueRef::owned(local_idx, ctx)
     }
 }
@@ -482,20 +482,19 @@ impl ValueRefBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bumpalo::Bump;
 
-    fn create_test_setup() -> (ValueAssignmentManager, RegisterFile) {
-        let assignments = ValueAssignmentManager::new();
-
+    fn create_register_file() -> RegisterFile {
         let mut allocatable = crate::core::register_file::RegBitSet::new();
         allocatable.union(&crate::core::register_file::RegBitSet::all_in_bank(0, 8));
-        let register_file = RegisterFile::new(8, 1, allocatable);
-
-        (assignments, register_file)
+        RegisterFile::new(8, 1, allocatable)
     }
 
     #[test]
     fn test_value_ref_creation() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let bump = Bump::new();
+        let mut assignments = ValueAssignmentManager::new_in(&bump);
+        let mut register_file = create_register_file();
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         // Create an assignment
@@ -512,7 +511,9 @@ mod tests {
 
     #[test]
     fn test_value_part_ref_allocation() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let bump = Bump::new();
+        let mut assignments = ValueAssignmentManager::new_in(&bump);
+        let mut register_file = create_register_file();
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         // Create an assignment
@@ -534,7 +535,9 @@ mod tests {
 
     #[test]
     fn test_modification_tracking() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let bump = Bump::new();
+        let mut assignments = ValueAssignmentManager::new_in(&bump);
+        let mut register_file = create_register_file();
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         ctx.assignments.create_assignment(42, 1, 8);

--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -150,7 +150,7 @@ pub struct LlvmCompiler<'ctx, 'arena> {
     session: &'arena CompilationSession<'arena>,
 
     /// Value assignment and tracking.
-    value_mgr: ValueAssignmentManager,
+    value_mgr: ValueAssignmentManager<'arena>,
 
     /// Register allocation state.
     register_file: RegisterFile,
@@ -242,7 +242,7 @@ where
         module: inkwell::module::Module<'ctx>,
         session: &'arena CompilationSession<'arena>,
     ) -> Result<Self, LlvmCompilerError> {
-        let value_mgr = ValueAssignmentManager::new();
+        let value_mgr = ValueAssignmentManager::new_in(session.arena());
         // Create register file with GP and XMM registers
         let mut allocatable = RegBitSet::new();
         allocatable.union(&RegBitSet::all_in_bank(0, 16)); // GP regs
@@ -302,7 +302,7 @@ where
         log::info!("🔧 Compiling LLVM function: {}", function_name);
 
         // Reset compiler state for new function
-        self.value_mgr = ValueAssignmentManager::new();
+        self.value_mgr = ValueAssignmentManager::new_in(self.session.arena());
         // Reset register file
         let mut allocatable = RegBitSet::new();
         allocatable.union(&RegBitSet::all_in_bank(0, 16)); // GP regs

--- a/rust/src/test_ir/compiler.rs
+++ b/rust/src/test_ir/compiler.rs
@@ -29,7 +29,7 @@ pub struct TestIRCompiler<'arena> {
     /// ELF assembler for object generation.
     assembler: ElfAssembler,
     /// Value assignment manager.
-    value_mgr: ValueAssignmentManager,
+    value_mgr: ValueAssignmentManager<'arena>,
     /// Register allocator.
     register_file: RegisterFile,
     /// Compilation session.
@@ -65,7 +65,7 @@ impl<'arena> TestIRCompiler<'arena> {
             ir,
             adaptor,
             assembler,
-            value_mgr: ValueAssignmentManager::new(),
+            value_mgr: ValueAssignmentManager::new_in(session.arena()),
             register_file: RegisterFile::new(16, 2, available_regs),
             _session: session,
             _no_fixed_assignments: no_fixed_assignments,
@@ -105,7 +105,7 @@ impl<'arena> TestIRCompiler<'arena> {
         self.adaptor.switch_func(FuncRef(func_idx as u32));
 
         // Reset per-function state
-        self.value_mgr = ValueAssignmentManager::new();
+        self.value_mgr = ValueAssignmentManager::new_in(self._session.arena());
         self.register_file = RegisterFile::new(16, 2, RegBitSet::all_in_bank(0, 16));
 
         // Create a new function codegen for this function


### PR DESCRIPTION
## Summary
- allocate ValueAssignment parts and free lists with bumpalo Vecs
- pass CompilationSession arena into value management structures
- plumb arena lifetimes through x64 backend and test IR compiler

## Testing
- `cargo test --offline`

------
https://chatgpt.com/codex/tasks/task_e_68442b85eae08326acde1d5e96a5658b