### PR TITLE
Use arena collections in assembler

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,8 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.16", features = ["allocator-api2", "collections"] }
+hashbrown = "0.15"
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
- eliminate heap use for label storage by using bumpalo
- track section offsets in an arena-backed hashmap

## Testing
- `cargo check --offline`
- `cargo test --offline`


------
https://chatgpt.com/codex/tasks/task_e_68442b874bdc832694f1e374885080a9