### PR TITLE
Switch FunctionFrame lists to BumpVec

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.16", features = ["allocator-api2", "collections"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -156,7 +156,7 @@ pub struct LlvmCompiler<'ctx, 'arena> {
     register_file: RegisterFile,
 
     /// Function code generation.
-    codegen: FunctionCodegen,
+    codegen: FunctionCodegen<'arena>,
 
     /// Cache of compiled functions.
     compiled_functions: HashMap<String, CompiledFunction<'arena>>,
@@ -249,7 +249,7 @@ where
         allocatable.union(&RegBitSet::all_in_bank(1, 16)); // XMM regs
         let register_file = RegisterFile::new(16, 2, allocatable);
         let codegen = map_err!(
-            FunctionCodegen::new(),
+            FunctionCodegen::new(session.arena()),
             CodeGeneration,
             "Failed to create codegen"
         )?;
@@ -309,7 +309,7 @@ where
         allocatable.union(&RegBitSet::all_in_bank(1, 16)); // XMM regs
         self.register_file = RegisterFile::new(16, 2, allocatable);
         self.codegen = map_err!(
-            FunctionCodegen::new(),
+            FunctionCodegen::new(self.session.arena()),
             CodeGeneration,
             "Failed to reset codegen"
         )?;
@@ -354,7 +354,7 @@ where
         // Take ownership of codegen and finalize
         let codegen = std::mem::replace(
             &mut self.codegen,
-            FunctionCodegen::new().map_err(|e| {
+            FunctionCodegen::new(self.session.arena()).map_err(|e| {
                 LlvmCompilerError::CodeGeneration(format!(
                     "Failed to create replacement codegen: {:?}",
                     e

--- a/rust/src/test_ir/compiler.rs
+++ b/rust/src/test_ir/compiler.rs
@@ -109,7 +109,7 @@ impl<'arena> TestIRCompiler<'arena> {
         self.register_file = RegisterFile::new(16, 2, RegBitSet::all_in_bank(0, 16));
 
         // Create a new function codegen for this function
-        let mut func_codegen = FunctionCodegen::new()?;
+        let mut func_codegen = FunctionCodegen::new(self._session.arena())?;
 
         // Process function arguments
         let arg_count = (func.arg_end_idx - func.arg_begin_idx) as usize;
@@ -189,7 +189,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_block(
         &mut self,
         block_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         let block = &self.ir.blocks[block_idx];
 
@@ -205,7 +205,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_instruction(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         let inst = &self.ir.values[inst_idx];
 
@@ -241,7 +241,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_binary_op<F>(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
         emit_op: F,
     ) -> Result<(), CompilationError>
     where
@@ -296,7 +296,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_add(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         self.compile_binary_op(inst_idx, func_codegen, |encoder, dst, src| {
             encoder.add_reg_reg(dst, src)
@@ -307,7 +307,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_sub(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         self.compile_binary_op(inst_idx, func_codegen, |encoder, dst, src| {
             encoder.sub_reg_reg(dst, src)
@@ -318,7 +318,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_ret(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         let inst = &self.ir.values[inst_idx];
 
@@ -350,7 +350,7 @@ impl<'arena> TestIRCompiler<'arena> {
     /// Compile a terminate instruction.
     fn compile_terminate(
         &mut self,
-        _func_codegen: &mut FunctionCodegen,
+        _func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         // For TestIR, terminate is like a void return
         // Epilogue will be generated at end of function
@@ -361,7 +361,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_branch(
         &mut self,
         _inst_idx: usize,
-        _func_codegen: &mut FunctionCodegen,
+        _func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         // TODO: Implement control flow with label management and jump instructions
         Ok(())
@@ -371,7 +371,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_alloca(
         &mut self,
         inst_idx: usize,
-        _func_codegen: &mut FunctionCodegen,
+        _func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         // Create value assignment for the result (a pointer to stack space)
         let local_idx = self.global_to_local_idx(inst_idx);
@@ -386,7 +386,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_call(
         &mut self,
         inst_idx: usize,
-        _func_codegen: &mut FunctionCodegen,
+        _func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         // Check if this call produces a result
         let inst = &self.ir.values[inst_idx];
@@ -404,7 +404,7 @@ impl<'arena> TestIRCompiler<'arena> {
     fn compile_zerofill(
         &mut self,
         inst_idx: usize,
-        func_codegen: &mut FunctionCodegen,
+        func_codegen: &mut FunctionCodegen<'arena>,
     ) -> Result<(), CompilationError> {
         let inst = &self.ir.values[inst_idx];
 


### PR DESCRIPTION
## Summary
- use bumpalo vectors for register slots and assignments
- add collections feature to bumpalo
- plumb arenas through FunctionCodegen and tests
- update LLVM and TestIR compilers for new FunctionCodegen API

## Testing
- `cargo test --offline --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68442b882b1883269f0e79ace629a371