### PR TITLE
Use bumpalo backed maps in x64 encoder

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,3 +32,4 @@ thiserror = "2.0"
 log = "0.4"
 env_logger = "0.11"
 clap = { version = "4.5", features = ["derive"] }
+hashbrown = { version = "0.15", features = ["allocator-api2"] }

--- a/rust/examples/test_call_instruction.rs
+++ b/rust/examples/test_call_instruction.rs
@@ -14,6 +14,7 @@
 
 use tpde::core::AsmReg;
 use tpde::x64::{Encoder as X64Encoder, EncodingError};
+use bumpalo::Bump;
 
 /// Test function call instruction generation.
 ///
@@ -37,7 +38,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn test_call_instruction_encoding() -> Result<(), EncodingError> {
     println!("📋 Testing CALL instruction encoding...");
 
-    let mut encoder = X64Encoder::new()?;
+    let bump = Bump::new();
+    let mut encoder = X64Encoder::new(&bump)?;
 
     // Test indirect call through register (call rax)
     let target_reg = AsmReg::new(0, 0); // RAX
@@ -71,7 +73,8 @@ fn test_call_instruction_encoding() -> Result<(), EncodingError> {
 fn test_complete_call_sequence() -> Result<(), EncodingError> {
     println!("📋 Testing complete function call sequence...");
 
-    let mut encoder = X64Encoder::new()?;
+    let bump = Bump::new();
+    let mut encoder = X64Encoder::new(&bump)?;
 
     // Simulate System V x86-64 calling convention
     let rdi = AsmReg::new(0, 7); // First argument register

--- a/rust/src/test_ir/compiler.rs
+++ b/rust/src/test_ir/compiler.rs
@@ -109,7 +109,7 @@ impl<'arena> TestIRCompiler<'arena> {
         self.register_file = RegisterFile::new(16, 2, RegBitSet::all_in_bank(0, 16));
 
         // Create a new function codegen for this function
-        let mut func_codegen = FunctionCodegen::new()?;
+        let mut func_codegen = FunctionCodegen::new(self._session.arena())?;
 
         // Process function arguments
         let arg_count = (func.arg_end_idx - func.arg_begin_idx) as usize;


### PR DESCRIPTION
## Summary
- use `hashbrown` with `Bump` allocator for `X64Encoder` label tracking
- thread bump allocator through encoder, instruction selector and backend
- update LLVM compiler and tests for allocator parameter
- fix example to pass bump allocator

## Testing
- `cargo test --offline --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68442b8b25b48326bb64d697c7312836