### PR TITLE
Arena allocated compiled functions map

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/bin/encodegen.rs"
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
 bumpalo = { version = "3.16", features = ["allocator-api2"] }
+hashbrown = { version = "0.15", features = ["allocator-api2"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -28,7 +28,8 @@ use crate::{
 use inkwell::basic_block::BasicBlock;
 use inkwell::values::BasicValueEnum;
 use inkwell::IntPredicate;
-use std::collections::HashMap;
+use bumpalo::Bump;
+use hashbrown::{HashMap, DefaultHashBuilder};
 
 /// Addressing modes for x86-64 memory operations.
 #[derive(Debug, Clone)]
@@ -158,8 +159,8 @@ pub struct LlvmCompiler<'ctx, 'arena> {
     /// Function code generation.
     codegen: FunctionCodegen,
 
-    /// Cache of compiled functions.
-    compiled_functions: HashMap<String, CompiledFunction<'arena>>,
+    /// Cache of compiled functions allocated in the session arena.
+    compiled_functions: HashMap<&'arena str, CompiledFunction<'arena>, DefaultHashBuilder, &'arena Bump>,
 
     /// Current function being compiled.
     current_function: Option<inkwell::values::FunctionValue<'ctx>>,
@@ -169,7 +170,7 @@ pub struct LlvmCompiler<'ctx, 'arena> {
 #[derive(Debug)]
 pub struct CompiledFunction<'arena> {
     /// Function name.
-    pub name: String,
+    pub name: &'arena str,
 
     /// Generated machine code.
     pub code: &'arena [u8],
@@ -260,7 +261,7 @@ where
             value_mgr,
             register_file,
             codegen,
-            compiled_functions: HashMap::new(),
+            compiled_functions: HashMap::new_in(session.arena()),
             current_function: None,
         })
     }
@@ -370,9 +371,10 @@ where
         // Allocate code in session arena
         let code_slice = self.session.alloc_slice(&code_bytes);
 
-        // Create compiled function record
+        // Intern name and create compiled function record
+        let name = self.session.intern_str(function_name);
         let compiled = CompiledFunction {
-            name: function_name.to_string(),
+            name,
             code: code_slice,
             entry_offset: 0,
             code_size: code_bytes.len(),
@@ -383,8 +385,7 @@ where
             .record_function_compiled(function_name, code_bytes.len());
 
         // Store in cache
-        self.compiled_functions
-            .insert(function_name.to_string(), compiled);
+        self.compiled_functions.insert(name, compiled);
         Ok(())
     }
 
@@ -3421,7 +3422,9 @@ where
     }
 
     /// Get list of compiled functions.
-    pub fn compiled_functions(&self) -> &HashMap<String, CompiledFunction<'arena>> {
+    pub fn compiled_functions(
+        &self,
+    ) -> &HashMap<&'arena str, CompiledFunction<'arena>, DefaultHashBuilder, &'arena Bump> {
         &self.compiled_functions
     }
 


### PR DESCRIPTION
## Summary
- store compiled functions in a HashMap that uses the session arena
- intern compiled function names and machine code buffers into the session

## Testing
- `cargo test --workspace --offline --no-run`
- `cargo test --workspace --offline --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68442b8d9bb88326ad5fff51d3726238