### PR TITLE
Arena-backed EnhancedLlvmAdaptor

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/bin/encodegen.rs"
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
 bumpalo = { version = "3.16", features = ["allocator-api2"] }
+hashbrown = { version = "0.15", features = ["allocator-api2"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/llvm/mod.rs
+++ b/rust/src/llvm/mod.rs
@@ -91,6 +91,7 @@ pub mod function_analysis;
 pub mod traits;
 
 // Main exports
-pub use adaptor::{EnhancedLlvmAdaptor as LlvmAdaptor, PhiInfo};
+pub use adaptor::{EnhancedLlvmAdaptor, PhiInfo};
+pub type LlvmAdaptor<'ctx, 'arena> = EnhancedLlvmAdaptor<'ctx, 'arena>;
 pub use compiler::{CompiledFunction, LlvmCompiler, LlvmCompilerError};
 pub use traits::{InstructionCategory, LlvmAdaptorInterface};


### PR DESCRIPTION
## Summary
- store EnhancedLlvmAdaptor data in CompilationSession arena
- add hashbrown dependency for arena allocated HashMap
- update module exports for new generic adaptor
- adjust unit tests

## Testing
- `cargo test --workspace --offline`

------
https://chatgpt.com/codex/tasks/task_e_68442b8d396083269e40b158ab4add28