### PR TITLE
Allocate register file arrays in compilation session

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/encodegen.rs"
 [dependencies]
 object = { version = "0.37", features = ["all"] }
 iced-x86 = { version = "1.21", features = ["code_asm"] }
-bumpalo = { version = "3.16", features = ["allocator-api2"] }
+bumpalo = { version = "3.16", features = ["allocator-api2", "collections"] }
 inkwell = { git = "https://github.com/stevefan1999-personal/inkwell.git", features = ["llvm19-1-prefer-dynamic"] }
 llvm-sys = { version = "191", features = ["prefer-dynamic"] }
 thiserror = "2.0"

--- a/rust/src/core/value_ref.rs
+++ b/rust/src/core/value_ref.rs
@@ -51,15 +51,15 @@ pub enum OwnershipMode {
 ///
 /// This allows ValueRef and ValuePartRef to access the necessary systems
 /// without holding direct references, avoiding Rust borrowing conflicts.
-pub struct CompilerContext<'a> {
+pub struct CompilerContext<'a, 'arena> {
     pub assignments: &'a mut ValueAssignmentManager,
-    pub register_file: &'a mut RegisterFile,
+    pub register_file: &'a mut RegisterFile<'arena>,
 }
 
-impl<'a> CompilerContext<'a> {
+impl<'a, 'arena> CompilerContext<'a, 'arena> {
     pub fn new(
         assignments: &'a mut ValueAssignmentManager,
-        register_file: &'a mut RegisterFile,
+        register_file: &'a mut RegisterFile<'arena>,
     ) -> Self {
         Self {
             assignments,
@@ -82,12 +82,12 @@ pub struct ValueRef {
     consumed: bool,
 }
 
-impl ValueRef {
+impl<'arena> ValueRef {
     /// Create a new ValueRef with the specified ownership mode.
     pub fn new(
         local_idx: ValLocalIdx,
         ownership: OwnershipMode,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, 'arena>,
     ) -> Self {
         // Add reference count if using ref-counted ownership
         if ownership == OwnershipMode::RefCounted {
@@ -104,7 +104,7 @@ impl ValueRef {
     }
 
     /// Create an owned ValueRef (takes exclusive ownership).
-    pub fn owned(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> Self {
+    pub fn owned(local_idx: ValLocalIdx, ctx: &mut CompilerContext<'_, 'arena>) -> Self {
         // For owned values, we need to add a reference that we'll remove on drop
         if let Some(assignment) = ctx.assignments.get_assignment_mut(local_idx) {
             assignment.add_ref();
@@ -118,7 +118,7 @@ impl ValueRef {
     }
 
     /// Create a ref-counted ValueRef (shared ownership).
-    pub fn ref_counted(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> Self {
+    pub fn ref_counted(local_idx: ValLocalIdx, ctx: &mut CompilerContext<'_, 'arena>) -> Self {
         Self::new(local_idx, OwnershipMode::RefCounted, ctx)
     }
 
@@ -128,7 +128,7 @@ impl ValueRef {
     }
 
     /// Get the number of parts for this value.
-    pub fn part_count(&self, ctx: &CompilerContext) -> Result<u32, ValueRefError> {
+    pub fn part_count(&self, ctx: &CompilerContext<'_, 'arena>) -> Result<u32, ValueRefError> {
         ctx.assignments
             .get_assignment(self.local_idx)
             .map(|a| a.part_count)
@@ -139,7 +139,7 @@ impl ValueRef {
     pub fn part(
         &self,
         part_idx: u32,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, 'arena>,
     ) -> Result<ValuePartRef, ValueRefError> {
         let part_count = self.part_count(ctx)?;
         if part_idx >= part_count {
@@ -150,12 +150,19 @@ impl ValueRef {
     }
 
     /// Access the first (and usually only) part of this value.
-    pub fn single_part(&self, ctx: &mut CompilerContext) -> Result<ValuePartRef, ValueRefError> {
+    pub fn single_part(
+        &self,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> Result<ValuePartRef, ValueRefError> {
         self.part(0, ctx)
     }
 
     /// Check if this value is currently assigned to a register.
-    pub fn is_in_register(&self, part_idx: u32, ctx: &CompilerContext) -> bool {
+    pub fn is_in_register(
+        &self,
+        part_idx: u32,
+        ctx: &CompilerContext<'_, 'arena>,
+    ) -> bool {
         if let Some(assignment) = ctx.assignments.get_assignment(self.local_idx) {
             if let Some(part_data) = assignment.part(part_idx) {
                 return part_data.register_valid();
@@ -165,7 +172,11 @@ impl ValueRef {
     }
 
     /// Get the register for a specific part if it's currently assigned.
-    pub fn current_register(&self, part_idx: u32, ctx: &CompilerContext) -> Option<AsmReg> {
+    pub fn current_register(
+        &self,
+        part_idx: u32,
+        ctx: &CompilerContext<'_, 'arena>,
+    ) -> Option<AsmReg> {
         if !self.is_in_register(part_idx, ctx) {
             return None;
         }
@@ -187,13 +198,13 @@ impl ValueRef {
     }
 
     /// Manually drop this ValueRef with access to the context.
-    pub fn drop_with_context(mut self, ctx: &mut CompilerContext) {
+    pub fn drop_with_context(mut self, ctx: &mut CompilerContext<'_, 'arena>) {
         self.cleanup(ctx);
         self.consumed = true; // Prevent double cleanup
     }
 
     /// Internal cleanup method.
-    fn cleanup(&mut self, ctx: &mut CompilerContext) {
+    fn cleanup(&mut self, ctx: &mut CompilerContext<'_, 'arena>) {
         if !self.consumed && self.ownership != OwnershipMode::Unowned {
             ctx.assignments.remove_ref(self.local_idx);
         }
@@ -215,7 +226,7 @@ pub struct ValuePartRef {
     modified: bool,
 }
 
-impl ValuePartRef {
+impl<'arena> ValuePartRef {
     /// Create a new ValuePartRef for the specified value part.
     pub fn new(local_idx: ValLocalIdx, part_idx: u32) -> Result<Self, ValueRefError> {
         log::trace!(
@@ -236,7 +247,10 @@ impl ValuePartRef {
     /// This is the primary method used by instruction selection to get
     /// a register containing the value. It handles allocation, reloading
     /// from stack, and locking automatically.
-    pub fn load_to_reg(&mut self, ctx: &mut CompilerContext) -> Result<AsmReg, ValueRefError> {
+    pub fn load_to_reg(
+        &mut self,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> Result<AsmReg, ValueRefError> {
         log::trace!(
             "load_to_reg for local_idx={}, part_idx={}",
             self.local_idx,
@@ -260,7 +274,10 @@ impl ValuePartRef {
     }
 
     /// Allocate a register for this part.
-    fn allocate_register(&mut self, ctx: &mut CompilerContext) -> Result<AsmReg, ValueRefError> {
+    fn allocate_register(
+        &mut self,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> Result<AsmReg, ValueRefError> {
         log::trace!(
             "allocate_register for local_idx={}, part_idx={}",
             self.local_idx,
@@ -318,7 +335,7 @@ impl ValuePartRef {
     pub fn alloc_try_reuse(
         &mut self,
         other: &mut ValuePartRef,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, 'arena>,
     ) -> Result<AsmReg, ValueRefError> {
         if let Some(other_reg) = other.current_register(ctx) {
             // Check if we can take ownership of the other register
@@ -335,7 +352,10 @@ impl ValuePartRef {
     }
 
     /// Get the current register for this part (if any).
-    pub fn current_register(&self, ctx: &CompilerContext) -> Option<AsmReg> {
+    pub fn current_register(
+        &self,
+        ctx: &CompilerContext<'_, 'arena>,
+    ) -> Option<AsmReg> {
         ctx.assignments
             .get_assignment(self.local_idx)
             .and_then(|assignment| assignment.part(self.part_idx))
@@ -344,7 +364,7 @@ impl ValuePartRef {
     }
 
     /// Check if this part can transfer ownership of its register.
-    fn can_transfer_ownership(&self, ctx: &CompilerContext) -> bool {
+    fn can_transfer_ownership(&self, ctx: &CompilerContext<'_, 'arena>) -> bool {
         // Can transfer if we have exclusive access and the register isn't shared
         self.locked_register.is_some()
             && ctx
@@ -355,7 +375,10 @@ impl ValuePartRef {
     }
 
     /// Release ownership of the current register.
-    fn release_register(&mut self, ctx: &mut CompilerContext) -> Result<(), ValueRefError> {
+    fn release_register(
+        &mut self,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> Result<(), ValueRefError> {
         if let Some(reg) = self.locked_register.take() {
             // Unlock the register
             ctx.register_file
@@ -376,7 +399,7 @@ impl ValuePartRef {
     fn claim_register(
         &mut self,
         reg: AsmReg,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, 'arena>,
     ) -> Result<(), ValueRefError> {
         // Update our assignment
         if let Some(assignment) = ctx.assignments.get_assignment_mut(self.local_idx) {
@@ -400,7 +423,7 @@ impl ValuePartRef {
     }
 
     /// Mark this part as modified (dirty).
-    pub fn set_modified(&mut self, ctx: &mut CompilerContext) {
+    pub fn set_modified(&mut self, ctx: &mut CompilerContext<'_, 'arena>) {
         self.modified = true;
         if let Some(reg) = self.current_register(ctx) {
             ctx.register_file.mark_clobbered(reg);
@@ -413,7 +436,10 @@ impl ValuePartRef {
     }
 
     /// Spill this part to memory if it's in a register.
-    pub fn spill(&mut self, ctx: &mut CompilerContext) -> Result<(), ValueRefError> {
+    pub fn spill(
+        &mut self,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> Result<(), ValueRefError> {
         if let Some(_reg) = self.current_register(ctx) {
             // In a real implementation, this would generate spill code
             // For now, we just mark the register as invalid
@@ -427,7 +453,7 @@ impl ValuePartRef {
     }
 
     /// Get the size of this part in bytes.
-    pub fn size_bytes(&self, ctx: &CompilerContext) -> u32 {
+    pub fn size_bytes(&self, ctx: &CompilerContext<'_, 'arena>) -> u32 {
         ctx.assignments
             .get_assignment(self.local_idx)
             .and_then(|assignment| assignment.part(self.part_idx))
@@ -436,12 +462,12 @@ impl ValuePartRef {
     }
 
     /// Manually drop this ValuePartRef with access to the context.
-    pub fn drop_with_context(mut self, ctx: &mut CompilerContext) {
+    pub fn drop_with_context(mut self, ctx: &mut CompilerContext<'_, 'arena>) {
         self.cleanup(ctx);
     }
 
     /// Internal cleanup method.
-    fn cleanup(&mut self, ctx: &mut CompilerContext) {
+    fn cleanup(&mut self, ctx: &mut CompilerContext<'_, 'arena>) {
         // Unlock any locked register
         if let Some(reg) = self.locked_register {
             let _ = ctx.register_file.unlock_register(reg);
@@ -455,11 +481,11 @@ impl ValuePartRef {
 /// and reference counting information.
 pub struct ValueRefBuilder;
 
-impl ValueRefBuilder {
+impl<'arena> ValueRefBuilder {
     /// Create a ValueRef with ownership determined by liveness analysis.
     pub fn build_for_value(
         local_idx: ValLocalIdx,
-        ctx: &mut CompilerContext,
+        ctx: &mut CompilerContext<'_, 'arena>,
         is_last_use: bool,
     ) -> ValueRef {
         let ownership = if is_last_use {
@@ -474,7 +500,10 @@ impl ValueRefBuilder {
     }
 
     /// Create a ValueRef for a result value (always owned).
-    pub fn build_for_result(local_idx: ValLocalIdx, ctx: &mut CompilerContext) -> ValueRef {
+    pub fn build_for_result(
+        local_idx: ValLocalIdx,
+        ctx: &mut CompilerContext<'_, 'arena>,
+    ) -> ValueRef {
         ValueRef::owned(local_idx, ctx)
     }
 }
@@ -483,19 +512,26 @@ impl ValueRefBuilder {
 mod tests {
     use super::*;
 
-    fn create_test_setup() -> (ValueAssignmentManager, RegisterFile) {
+    use bumpalo::Bump;
+    use crate::core::CompilationSession;
+
+    fn create_test_setup<'arena>(
+        session: &'arena CompilationSession<'arena>,
+    ) -> (ValueAssignmentManager, RegisterFile<'arena>) {
         let assignments = ValueAssignmentManager::new();
 
         let mut allocatable = crate::core::register_file::RegBitSet::new();
         allocatable.union(&crate::core::register_file::RegBitSet::all_in_bank(0, 8));
-        let register_file = RegisterFile::new(8, 1, allocatable);
+        let register_file = RegisterFile::new(session, 8, 1, allocatable);
 
         (assignments, register_file)
     }
 
     #[test]
     fn test_value_ref_creation() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let arena = Bump::new();
+        let session = CompilationSession::new(&arena);
+        let (mut assignments, mut register_file) = create_test_setup(&session);
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         // Create an assignment
@@ -512,7 +548,9 @@ mod tests {
 
     #[test]
     fn test_value_part_ref_allocation() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let arena = Bump::new();
+        let session = CompilationSession::new(&arena);
+        let (mut assignments, mut register_file) = create_test_setup(&session);
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         // Create an assignment
@@ -534,7 +572,9 @@ mod tests {
 
     #[test]
     fn test_modification_tracking() {
-        let (mut assignments, mut register_file) = create_test_setup();
+        let arena = Bump::new();
+        let session = CompilationSession::new(&arena);
+        let (mut assignments, mut register_file) = create_test_setup(&session);
         let mut ctx = CompilerContext::new(&mut assignments, &mut register_file);
 
         ctx.assignments.create_assignment(42, 1, 8);

--- a/rust/src/llvm/compiler.rs
+++ b/rust/src/llvm/compiler.rs
@@ -153,7 +153,7 @@ pub struct LlvmCompiler<'ctx, 'arena> {
     value_mgr: ValueAssignmentManager,
 
     /// Register allocation state.
-    register_file: RegisterFile,
+    register_file: RegisterFile<'arena>,
 
     /// Function code generation.
     codegen: FunctionCodegen,
@@ -247,7 +247,7 @@ where
         let mut allocatable = RegBitSet::new();
         allocatable.union(&RegBitSet::all_in_bank(0, 16)); // GP regs
         allocatable.union(&RegBitSet::all_in_bank(1, 16)); // XMM regs
-        let register_file = RegisterFile::new(16, 2, allocatable);
+        let register_file = RegisterFile::new(session, 16, 2, allocatable);
         let codegen = map_err!(
             FunctionCodegen::new(),
             CodeGeneration,
@@ -307,7 +307,7 @@ where
         let mut allocatable = RegBitSet::new();
         allocatable.union(&RegBitSet::all_in_bank(0, 16)); // GP regs
         allocatable.union(&RegBitSet::all_in_bank(1, 16)); // XMM regs
-        self.register_file = RegisterFile::new(16, 2, allocatable);
+        self.register_file = RegisterFile::new(self.session, 16, 2, allocatable);
         self.codegen = map_err!(
             FunctionCodegen::new(),
             CodeGeneration,

--- a/rust/src/test_ir/compiler.rs
+++ b/rust/src/test_ir/compiler.rs
@@ -31,7 +31,7 @@ pub struct TestIRCompiler<'arena> {
     /// Value assignment manager.
     value_mgr: ValueAssignmentManager,
     /// Register allocator.
-    register_file: RegisterFile,
+    register_file: RegisterFile<'arena>,
     /// Compilation session.
     _session: &'arena CompilationSession<'arena>,
     /// Whether to disable fixed register assignments.
@@ -66,7 +66,7 @@ impl<'arena> TestIRCompiler<'arena> {
             adaptor,
             assembler,
             value_mgr: ValueAssignmentManager::new(),
-            register_file: RegisterFile::new(16, 2, available_regs),
+            register_file: RegisterFile::new(session, 16, 2, available_regs),
             _session: session,
             _no_fixed_assignments: no_fixed_assignments,
         })
@@ -106,7 +106,7 @@ impl<'arena> TestIRCompiler<'arena> {
 
         // Reset per-function state
         self.value_mgr = ValueAssignmentManager::new();
-        self.register_file = RegisterFile::new(16, 2, RegBitSet::all_in_bank(0, 16));
+        self.register_file = RegisterFile::new(self._session, 16, 2, RegBitSet::all_in_bank(0, 16));
 
         // Create a new function codegen for this function
         let mut func_codegen = FunctionCodegen::new()?;

--- a/rust/src/x64/backend.rs
+++ b/rust/src/x64/backend.rs
@@ -20,6 +20,7 @@ use crate::core::{
     assembler::ElfAssembler,
     register_file::{RegAllocError, RegBitSet, RegisterFile},
     value_assignment::ValueAssignmentManager,
+    session::CompilationSession,
     Backend, CompilerBase, CompilerContext, IrAdaptor, ValuePartRef, ValueRefError,
 };
 
@@ -63,23 +64,23 @@ impl From<EncodingError> for X64BackendError {
 /// - RegisterFile for register allocation
 /// - ValueRef/ValuePartRef for instruction selection
 /// - X64Encoder for machine code generation
-pub struct X64Backend {
+pub struct X64Backend<'arena> {
     /// Value assignment tracking.
     value_mgr: ValueAssignmentManager,
     /// Register allocator.
-    register_file: RegisterFile,
+    register_file: RegisterFile<'arena>,
     /// Instruction encoder.
     encoder: InstructionSelector,
     /// Current stack frame size.
     frame_size: u32,
 }
 
-impl X64Backend {
+impl<'arena> X64Backend<'arena> {
     /// Create a new x86-64 backend.
-    pub fn new() -> Result<Self, X64BackendError> {
+    pub fn new(session: &'arena CompilationSession<'arena>) -> Result<Self, X64BackendError> {
         Ok(Self {
             value_mgr: ValueAssignmentManager::new(),
-            register_file: RegisterFile::new(16, 2, RegBitSet::all_in_bank(0, 16)),
+            register_file: RegisterFile::new(session, 16, 2, RegBitSet::all_in_bank(0, 16)),
             encoder: InstructionSelector::new()?,
             frame_size: 0,
         })
@@ -180,7 +181,7 @@ enum BinaryOpType {
     Sub,
 }
 
-impl<A: IrAdaptor> Backend<A, ElfAssembler> for X64Backend {
+impl<'arena, A: IrAdaptor> Backend<A, ElfAssembler> for X64Backend<'arena> {
     fn gen_prologue(&mut self, _base: &mut CompilerBase<A, ElfAssembler, Self>) {
         // Emit function prologue
         self.encoder.emit_prologue(self.frame_size).unwrap();
@@ -231,12 +232,13 @@ impl<A: IrAdaptor> Backend<A, ElfAssembler> for X64Backend {
 }
 
 /// Helper function to create a complete x86-64 compilation pipeline.
-pub fn create_x64_compiler<A: IrAdaptor>(
+pub fn create_x64_compiler<'arena, A: IrAdaptor>(
     adaptor: A,
-) -> Result<CompilerBase<A, ElfAssembler, X64Backend>, X64BackendError> {
+    session: &'arena CompilationSession<'arena>,
+) -> Result<CompilerBase<A, ElfAssembler, X64Backend<'arena>>, X64BackendError> {
     use crate::core::assembler::Assembler;
     let assembler = <ElfAssembler as Assembler<A>>::new(true);
-    let backend = X64Backend::new()?;
+    let backend = X64Backend::new(session)?;
     Ok(CompilerBase::new(adaptor, assembler, backend))
 }
 
@@ -244,6 +246,8 @@ pub fn create_x64_compiler<A: IrAdaptor>(
 mod tests {
     use super::*;
     use crate::core::IrAdaptor;
+    use crate::core::CompilationSession;
+    use bumpalo::Bump;
 
     /// Minimal test IR adaptor for demonstrating the backend.
     struct TestIrAdaptor {
@@ -386,7 +390,9 @@ mod tests {
 
     #[test]
     fn test_x64_backend_creation() {
-        let backend = X64Backend::new();
+        let arena = Bump::new();
+        let session = CompilationSession::new(&arena);
+        let backend = X64Backend::new(&session);
         assert!(backend.is_ok());
     }
 


### PR DESCRIPTION
## Summary
- store `assignments` and `lock_counts` in bump arena backed vectors
- pass `CompilationSession` to `RegisterFile::new`
- adjust compiler backends and tests for new lifetime parameter
- enable the `collections` feature for `bumpalo`

## Testing
- `cargo test --workspace --offline`

------
https://chatgpt.com/codex/tasks/task_e_68442b86b80c8326bf16e9841026a281